### PR TITLE
feat: Add Email Guidelines section with voice, tone, and formatting documentation

### DIFF
--- a/src/app/email-guidelines/examples/page.tsx
+++ b/src/app/email-guidelines/examples/page.tsx
@@ -1,0 +1,105 @@
+import Image from "next/image"
+import { Check } from "lucide-react"
+
+const emailExamples = [
+  {
+    title: "Vercel Live Session Invite",
+    subject: "Agentic commerce is coming. Here's how to prepare.",
+    preheader: "Commerce is expanding beyond storefronts and checkout pages",
+    image: "/images/email-example-1.png",
+    imageAlt: "Vercel Live session invitation email example showing proper formatting with speaker title, bullet points without periods, date/time formatting, CTA button, and signature spacing",
+    highlights: [
+      "Speaker title is written correctly (title before name, no comma)",
+      "No periods at the end of the bullet points",
+      "Date and time clearly called out and in the right format",
+      "Closing signature has correct spacing",
+      "CTA button is used instead of hyperlinking text",
+    ],
+  },
+  {
+    title: "Finance Team Internal Apps",
+    subject: "How finance automates financial workflows with v0 pipelines",
+    preheader: "Last chance to join the v0 Financial Workflows webinar",
+    image: "/images/email-example-2.png",
+    imageAlt: "Vercel finance team email example showing proper formatting with bullet points without periods, date with day of week and timezone spacing, CTA button, and signature spacing",
+    highlights: [
+      "Bullet points do not contain periods",
+      "Date includes day of the week and proper spacing between PM and timezones",
+      "CTA button used instead of hyperlinking",
+      "Closing follows spacing guidelines",
+    ],
+  },
+  {
+    title: "Vercel Ship 2025 - AEO Session",
+    subject: "How to engineer your site for LLMs and AI search optimization",
+    preheader: "Best practices from startup Profound",
+    image: "/images/email-example-3.png",
+    imageAlt: "Vercel Ship 2025 email about answer engine optimization featuring banner image with speaker, proper title formatting, bullet points without periods, and CTA button with hyperlink",
+    highlights: [
+      "Includes banner image with speaker headshot",
+      "Speaker title comes before their name with no comma separation",
+      "No periods on bullet points",
+      "CTA button in addition to hyperlink",
+    ],
+  },
+]
+
+export default function EmailExamplesPage() {
+  return (
+    <div className="space-y-12">
+      {/* Header */}
+      <section className="space-y-4">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          Email Examples
+        </h1>
+        <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
+          Real examples of emails that follow our voice, tone, and formatting guidelines.
+        </p>
+      </section>
+
+      {emailExamples.map((example, exampleIndex) => (
+        <section key={exampleIndex} className="space-y-6">
+          <h2 className="text-xl font-semibold text-foreground">{example.title}</h2>
+          
+          {/* Subject & Preheader */}
+          <div className="rounded-lg border border-border bg-card p-4 space-y-2">
+            <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-3">
+              <span className="text-sm font-medium text-foreground shrink-0 w-20">Subject:</span>
+              <span className="text-sm text-muted-foreground">{example.subject}</span>
+            </div>
+            <div className="flex flex-col sm:flex-row sm:items-start gap-1 sm:gap-3">
+              <span className="text-sm font-medium text-foreground shrink-0 w-20">Preheader:</span>
+              <span className="text-sm text-muted-foreground">{example.preheader}</span>
+            </div>
+          </div>
+          
+          {/* Email Image */}
+          <div className="rounded-lg border border-border overflow-hidden bg-white">
+            <Image
+              src={example.image || "/placeholder.svg"}
+              alt={example.imageAlt}
+              width={1000}
+              height={1800}
+              className="w-full h-auto"
+            />
+          </div>
+
+          {/* What was done well */}
+          <div className="rounded-lg border border-border bg-card p-6">
+            <h3 className="text-base font-semibold text-foreground mb-4">What was done well</h3>
+            <ul className="space-y-3">
+              {example.highlights.map((item, index) => (
+                <li key={index} className="flex items-start gap-3">
+                  <span className="shrink-0 mt-0.5">
+                    <Check className="h-4 w-4 text-green-500" />
+                  </span>
+                  <span className="text-sm text-muted-foreground">{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/src/app/email-guidelines/formatting/page.tsx
+++ b/src/app/email-guidelines/formatting/page.tsx
@@ -1,0 +1,217 @@
+import { CopyCard } from "@/components/docs/copy-card"
+
+export default function EmailFormattingPage() {
+  return (
+    <div className="space-y-12">
+      {/* Header */}
+      <section className="space-y-4">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          Email Formatting
+        </h1>
+        <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
+          Standards and formatting rules for Vercel marketing emails. Follow these guidelines to ensure consistency across all communications.
+        </p>
+      </section>
+
+      {/* Subject Line */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Subject Line</h2>
+        </div>
+
+        <div className="grid gap-3">
+          <CopyCard
+            variant="do"
+            title="Be mindful of optimal length"
+            content="~35 characters, up to 50 characters max."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="One clear idea"
+            content="One subject line = one promise or benefit. No bundling."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Clarity over cleverness"
+            content="It should be instantly understandable while scanning an inbox."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Lead with specificity"
+            content="Put the most concrete, meaningful words first (numbers, outcomes, changes)."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Cut filler aggressively"
+            content="Remove words that add length but no value: 'introducing,' 'exciting,' 'update.'"
+            hideCopy
+          />
+        </div>
+      </section>
+
+      {/* Pre-header */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Pre-header</h2>
+        </div>
+
+        <div className="grid gap-3">
+          <CopyCard
+            variant="do"
+            title="Be mindful of optimal length"
+            content="Between 40-90 characters."
+            hideCopy
+          />
+          <CopyCard
+            variant="dont"
+            title="No punctuation"
+            content="We do not use punctuation in pre-headers as a general rule of thumb."
+            hideCopy
+          />
+          <CopyCard
+            variant="dont"
+            title="Never repeat the subject line"
+            content="Treat the preheader as line 2 of the sentence, not an echo."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Finish the thought from the subject line"
+            content="Preheader = context, payoff, or proof."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Front-load the value"
+            content="Put the most important information at the beginning of the preheader."
+            hideCopy
+          />
+        </div>
+      </section>
+
+      {/* Job Titles */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Job Titles</h2>
+        </div>
+
+        <div className="grid gap-3">
+          <CopyCard
+            variant="do"
+            title="Title before name"
+            content="Campaign Operations Manager Ethan White"
+            hideCopy
+          />
+          <CopyCard
+            variant="dont"
+            title="Don't use comma separation or include Vercel"
+            content="Ethan White, Campaign Operations Manager, Vercel
+Do not include Vercel in the title unless there are multiple companies participating in the event."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Guillermo's title"
+            content="When mentioning Guillermo, it should always read 'Vercel Founder & CEO Guillermo Rauch'"
+            hideCopy
+          />
+        </div>
+      </section>
+
+      {/* Dates and Times */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Dates and Times</h2>
+        </div>
+
+        <div className="grid gap-3">
+          <CopyCard
+            variant="do"
+            title="Date format"
+            content="Always include the day of the week and year: Thursday, January 22, 2026"
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Time format"
+            content="10:00 AM PT (note the spacing)"
+            hideCopy
+          />
+        </div>
+      </section>
+
+      {/* Images */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Images</h2>
+        </div>
+
+        <div className="grid gap-3">
+          <CopyCard
+            variant="do"
+            title="Include a banner image"
+            content="Emails should include a banner image whenever possible as this has been shown to increase CTR. The banner should be 600px wide and 200-400px tall."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Include speaker headshots"
+            content="Emails should include a speaker headshot whenever possible/relevant."
+            hideCopy
+          />
+        </div>
+      </section>
+
+      {/* Bullet Points */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Bullet Points</h2>
+        </div>
+
+        <div className="grid gap-3">
+          <CopyCard
+            variant="dont"
+            title="No periods at the end"
+            content="Bullet points should not have periods at the end"
+            hideCopy
+          />
+        </div>
+      </section>
+
+      {/* UTMs */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">UTMs</h2>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            MOPs will create UTMs for you, but if there is a specific UTM you would like to use for tracking, please provide that in your <span className="font-mono text-foreground">#review-emails</span> request.
+          </p>
+        </div>
+      </section>
+
+      {/* Signature */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Signature</h2>
+          <p className="text-sm text-muted-foreground">
+            When including a closing signature, there should be a hard return between the closing and the Vercel team line.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5">
+          <div className="font-mono text-sm text-foreground whitespace-pre-line leading-loose">
+            {`See you soon,
+
+▲ The Vercel Team`}
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/email-guidelines/layout.tsx
+++ b/src/app/email-guidelines/layout.tsx
@@ -1,0 +1,169 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+import { cn } from "@/lib/utils"
+import { BookOpen, CheckSquare, Mail, Download, Menu, X, ArrowLeft } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useState, useEffect } from "react"
+
+const NAV_ITEMS = [
+  { name: "Voice & Tone", href: "/email-guidelines", icon: BookOpen },
+  { name: "Email Formatting", href: "/email-guidelines/formatting", icon: CheckSquare },
+  { name: "Examples", href: "/email-guidelines/examples", icon: Mail },
+  { name: "Resources", href: "/email-guidelines/resources", icon: Download },
+]
+
+function VercelLogo() {
+  return (
+    <svg
+      aria-label="Vercel Logo"
+      fill="currentColor"
+      viewBox="0 0 75 65"
+      height="18"
+      className="text-foreground"
+    >
+      <path d="M37.5 0L75 65H0L37.5 0Z" />
+    </svg>
+  )
+}
+
+function NavLinks({ onNavigate }: { onNavigate?: () => void }) {
+  const pathname = usePathname()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return (
+      <>
+        {NAV_ITEMS.map((item) => (
+          <span
+            key={item.href}
+            className="px-3 py-2 text-sm font-medium rounded-md text-muted-foreground"
+          >
+            {item.name}
+          </span>
+        ))}
+      </>
+    )
+  }
+
+  return (
+    <>
+      {NAV_ITEMS.map((item) => {
+        const isActive = pathname === item.href
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={onNavigate}
+            className={cn(
+              "px-3 py-2 text-sm font-medium rounded-md transition-colors",
+              isActive
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            {item.name}
+          </Link>
+        )
+      })}
+    </>
+  )
+}
+
+function MobileNavLinks({ onNavigate }: { onNavigate: () => void }) {
+  const pathname = usePathname()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return null
+  }
+
+  return (
+    <>
+      {NAV_ITEMS.map((item) => {
+        const isActive = pathname === item.href
+        const Icon = item.icon
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={onNavigate}
+            className={cn(
+              "flex items-center gap-3 px-3 py-2.5 text-sm font-medium rounded-md transition-colors",
+              isActive
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:text-foreground hover:bg-accent/50"
+            )}
+            aria-current={isActive ? "page" : undefined}
+          >
+            <Icon className="h-4 w-4" aria-hidden="true" />
+            {item.name}
+          </Link>
+        )
+      })}
+    </>
+  )
+}
+
+export default function EmailGuidelinesLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+        <div className="flex h-14 items-center gap-6 px-4 sm:px-6">
+          <Link href="/" className="shrink-0 flex items-center gap-2 text-muted-foreground hover:text-foreground transition-colors" aria-label="Back to Marketing Toolkit">
+            <ArrowLeft className="h-4 w-4" />
+            <VercelLogo />
+          </Link>
+
+          {/* Desktop Navigation */}
+          <nav className="hidden md:flex items-center gap-1" aria-label="Email guidelines navigation">
+            <NavLinks />
+          </nav>
+
+          <div className="flex-1" />
+
+          {/* Mobile menu button */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
+            aria-label="Toggle navigation menu"
+            aria-expanded={mobileMenuOpen}
+          >
+            {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </Button>
+        </div>
+
+        {/* Mobile Navigation */}
+        {mobileMenuOpen && (
+          <nav className="md:hidden border-t border-border bg-background p-2" aria-label="Mobile navigation">
+            <MobileNavLinks onNavigate={() => setMobileMenuOpen(false)} />
+          </nav>
+        )}
+      </header>
+
+      <main className="w-full">
+        <div className="max-w-4xl mx-auto px-4 py-8 sm:px-6 lg:px-8">
+          {children}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/src/app/email-guidelines/page.tsx
+++ b/src/app/email-guidelines/page.tsx
@@ -1,0 +1,339 @@
+import { CopyCard } from "@/components/docs/copy-card"
+import { SamplePanel } from "@/components/docs/sample-panel"
+import { ArrowUpRight } from "lucide-react"
+import Link from "next/link"
+
+export default function EmailGuidelinesPage() {
+  return (
+    <div className="space-y-16">
+      {/* Content Analyzer CTA */}
+      <Link
+        href="/content-analyzer"
+        className="group relative flex items-center justify-between gap-6 rounded-xl border border-blue-500/30 bg-gradient-to-r from-blue-500/10 via-blue-500/5 to-transparent p-6 transition-all hover:border-blue-500/50 hover:from-blue-500/15 hover:via-blue-500/10"
+      >
+        <div className="absolute inset-0 rounded-xl bg-blue-500/5 opacity-0 transition-opacity group-hover:opacity-100" />
+        <div className="relative space-y-2">
+          <div className="flex items-center gap-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-blue-500/20">
+              <svg
+                className="h-4 w-4 text-blue-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            </div>
+            <h2 className="text-base font-semibold text-foreground">
+              Content Analyzer
+            </h2>
+          </div>
+          <p className="text-sm text-muted-foreground max-w-md">
+            Paste your draft and instantly check it against our voice and tone guidelines
+          </p>
+        </div>
+        <div className="relative flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-blue-500/30 bg-blue-500/10 transition-all group-hover:border-blue-500/50 group-hover:bg-blue-500/20">
+          <ArrowUpRight className="h-5 w-5 text-blue-400 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+        </div>
+      </Link>
+
+      {/* Header */}
+      <section className="space-y-4">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          Voice & Tone Guidelines
+        </h1>
+        <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
+          How we apply voice and tone in the words we write. Recommendations may seem
+          contradicting, and that&apos;s ok. There are exceptions to every rule. The goal is
+          to keep these tips in mind and find the balance.
+        </p>
+      </section>
+
+      {/* Keep Sentences Short */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Keep sentences short</h2>
+          <p className="text-muted-foreground">
+            Every sentence should be purposeful and drive the reader forward. Fewer commas.
+            More periods. Using fewer words lets the words you keep feel intentional.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5 space-y-4">
+          <h3 className="text-sm font-medium text-foreground">Writing tips</h3>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Write short, declarative sentences.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Every time you use a comma, ask yourself whether you can use a period instead.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              A great sentence is a good sentence made shorter. Write with the delete key. You know a sentence is ready to ship when there&apos;s nothing left to remove.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Avoid repeating the same words in a paragraph. Try to rephrase, or use synonyms when possible.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Remove unnecessary &quot;filler&quot; words: &quot;This is <s>very</s> good.&quot; — Very adds nothing.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      {/* Vary Sentence Length */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Vary sentence length</h2>
+          <p className="text-muted-foreground">
+            We want to keep sentences short, but we should avoid sounding robotic. Mix your phrasing to make reading interesting.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5 space-y-4">
+          <h3 className="text-sm font-medium text-foreground">Writing tips</h3>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Use short sentences to make impactful statements or as a bridge between two statements.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Use longer sentences to build momentum.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Varying the sentence length gives the paragraph life and personality.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Use em dashes to change things up.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      {/* Write Like You Speak */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Write like you speak</h2>
+          <p className="text-muted-foreground">
+            It&apos;s tempting to use words or phrases to sound more impressive or smart, but it usually has the opposite effect. It clouds the points you&apos;re trying to make. Write like you speak.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5 space-y-4">
+          <h3 className="text-sm font-medium text-foreground">Writing tips</h3>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Don&apos;t get fancy. Get to the point faster. If you can, always use the shorter, simpler word.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Sentences can start with &quot;but&quot; and &quot;and&quot;, but don&apos;t overdo it.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Jargon and fluff can surface when there is a lack of clarity or facts. Dig deeper to uncover the underlying targets, facts, and data.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              Avoid corporate jargon and marketing fluff. If it doesn&apos;t add meaningful value, cut it.
+            </li>
+          </ul>
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-3">
+          <WordSwap before="Facilitate" after="Help" />
+          <WordSwap before="Utilize" after="Use" />
+          <WordSwap before="Commence" after="Start" />
+        </div>
+
+        <SamplePanel
+          before="Observability is mission-critical."
+          after="Observability is important."
+        />
+      </section>
+
+      {/* Be Specific */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Be specific</h2>
+          <p className="text-muted-foreground">
+            We can use words like &quot;best&quot;, &quot;bigger&quot;, &quot;better&quot;, and &quot;faster&quot;, but it&apos;s more powerful when we can back statements with facts or data. Explicitly stating &quot;why&quot; or &quot;how&quot; is more concrete.
+          </p>
+          <p className="text-muted-foreground">
+            If you do use these superlatives, use them sparingly. If everything is &quot;great&quot;, then nothing is.
+          </p>
+        </div>
+
+        <SamplePanel
+          before="Vercel is fast"
+          after="With zero-configuration support for 35+ frameworks, Vercel gets your team building faster"
+        />
+      </section>
+
+      {/* Be Confident */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Be confident</h2>
+          <p className="text-muted-foreground">
+            We&apos;re confident in our product and the value it provides. Phrases like &quot;I think,&quot; &quot;maybe,&quot; &quot;could,&quot; etc., soften our impact. Vercel is an authority in our space. Be bold. But also, be humble.
+          </p>
+          <p className="text-muted-foreground">
+            Know the difference between confidence and arrogance.
+          </p>
+        </div>
+
+        <SamplePanel
+          before="Vercel should make your app faster"
+          after="Vercel's Edge Network is built on a global infrastructure designed for optimal performance and reliability"
+        />
+      </section>
+
+      {/* Highlight Customers */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Highlight customers and community</h2>
+          <p className="text-muted-foreground">
+            Our customers and community are filled with builders and creators from around the world. Featuring their thoughts and words allows us to give them the spotlight and show value versus telling. Our favorite moments are when our customers do the talking for us.
+          </p>
+        </div>
+
+        <SamplePanel
+          before="Vercel is fast."
+          after={`"Switching to Edge Functions improved our site load times by 60%." — ACME`}
+        />
+      </section>
+
+      {/* Say "You" More */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Say &quot;you&quot; more than &quot;we&quot;</h2>
+          <p className="text-muted-foreground">
+            When talking to an external audience, the conversation should be more about them than us. Less &quot;we did&quot; and more &quot;you can&quot;.
+          </p>
+          <p className="text-muted-foreground">
+            We know how great Vercel can be. We help others understand by showing the impact Vercel can have on their team and empathizing with their software development challenges.
+          </p>
+        </div>
+
+        <SamplePanel
+          before="Edge Functions make personalization faster."
+          after="With Edge Functions, you can personalize and experiment without sacrificing speed or performance."
+        />
+      </section>
+
+      {/* Active Voice */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Use active voice</h2>
+          <p className="text-muted-foreground">
+            Active voice is more interesting to read and leaves less room for ambiguity. The active form makes sentences more vigorous, direct, and efficient.
+          </p>
+        </div>
+
+        <div className="rounded-lg border border-border bg-card p-5 space-y-4">
+          <h3 className="text-sm font-medium text-foreground">Writing tips</h3>
+          <ul className="space-y-2 text-sm text-muted-foreground">
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              If you find yourself using words like &quot;has&quot;, &quot;was&quot;, &quot;by&quot;, or words ending with &quot;-ed&quot;, you may be using passive voice. Try to restructure the sentence.
+            </li>
+            <li className="flex gap-2">
+              <span className="text-foreground">•</span>
+              A tip for catching passive voice: add &quot;...by monkeys&quot; to the end of the sentence. If it makes sense, you&apos;re using passive voice.
+            </li>
+          </ul>
+        </div>
+
+        <div className="space-y-4">
+          <SamplePanel
+            before="If you make changes to your code, the page will be updated."
+            after="To update the page, make changes to your code."
+          />
+          <SamplePanel
+            before="The account was created."
+            after="You created an account."
+          />
+        </div>
+      </section>
+
+      {/* Positive Phrasing */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Use positive phrasing</h2>
+          <p className="text-muted-foreground">
+            Positive phrasing is easier to understand than negative. We can be more clear saying what something is than trying to express what it isn&apos;t. A positive tone is uplifting and enabling. Negative tone creates tension, apprehension, or limitation.
+          </p>
+          <p className="text-muted-foreground">
+            Conjunctions can also feel negative. Swapping them out can turn a confrontational statement into a positive one.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <SamplePanel
+            before="You can't update the page if you don't make any changes to your code."
+            after="To update the page, make changes to your code."
+          />
+          <SamplePanel
+            before="We're excited for you to join us. However, you need to confirm your account."
+            after="We're excited for you to join us. There's one thing left to do: Confirm your account."
+          />
+        </div>
+      </section>
+
+      {/* Exclamation Points */}
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold text-foreground">Use exclamation points thoughtfully</h2>
+          <p className="text-muted-foreground">
+            Almost never use exclamation points. When we do use them, it&apos;s very sparingly. Treat exclamation points like salt. They add flavor, while too much ruins the dish. Exclamation points also lose their emphasis over time. If everything is worth an exclamation point, then nothing is.
+          </p>
+        </div>
+
+        <div className="grid gap-3">
+          <CopyCard
+            variant="dont"
+            title="Not from a company account"
+            content="Never use exclamation points in company messages or official communications."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Maybe when congratulating"
+            content="Ok when congratulating a customer—never when something's gone wrong. No one likes being yelled at."
+            hideCopy
+          />
+          <CopyCard
+            variant="do"
+            title="Personal communication"
+            content="Ok from personal accounts or in direct one-on-one communication with a customer."
+            hideCopy
+          />
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function WordSwap({ before, after }: { before: string; after: string }) {
+  return (
+    <div className="rounded-lg border border-border bg-card p-4 text-center">
+      <p className="text-sm text-muted-foreground line-through mb-1">{before}</p>
+      <p className="text-sm font-medium text-foreground">{after}</p>
+    </div>
+  )
+}

--- a/src/app/email-guidelines/resources/page.tsx
+++ b/src/app/email-guidelines/resources/page.tsx
@@ -1,0 +1,101 @@
+import { ArrowUpRight } from "lucide-react"
+import Link from "next/link"
+
+const tools = [
+  {
+    title: "Content Analyzer",
+    description: "Check your content against our voice and tone guidelines",
+    url: "/content-analyzer",
+    color: "blue",
+  },
+  {
+    title: "UTM Generator",
+    description: "Create UTM parameters for campaign tracking",
+    url: "/utm-generator",
+    color: "emerald",
+  },
+  {
+    title: "Naming Generator",
+    description: "Generate consistent naming for campaigns and assets",
+    url: "/naming-generators",
+    color: "violet",
+  },
+  {
+    title: "Email Review Agent",
+    description: "Get AI-powered feedback on your email drafts",
+    url: "/email-review",
+    color: "amber",
+  },
+]
+
+const colorClasses = {
+  blue: {
+    border: "border-blue-500/30 hover:border-blue-500/50",
+    bg: "from-blue-500/10 via-blue-500/5 to-transparent hover:from-blue-500/15 hover:via-blue-500/10",
+    icon: "bg-blue-500/20 border-blue-500/30 group-hover:border-blue-500/50 group-hover:bg-blue-500/20",
+    iconColor: "text-blue-400",
+  },
+  emerald: {
+    border: "border-emerald-500/30 hover:border-emerald-500/50",
+    bg: "from-emerald-500/10 via-emerald-500/5 to-transparent hover:from-emerald-500/15 hover:via-emerald-500/10",
+    icon: "bg-emerald-500/20 border-emerald-500/30 group-hover:border-emerald-500/50 group-hover:bg-emerald-500/20",
+    iconColor: "text-emerald-400",
+  },
+  violet: {
+    border: "border-violet-500/30 hover:border-violet-500/50",
+    bg: "from-violet-500/10 via-violet-500/5 to-transparent hover:from-violet-500/15 hover:via-violet-500/10",
+    icon: "bg-violet-500/20 border-violet-500/30 group-hover:border-violet-500/50 group-hover:bg-violet-500/20",
+    iconColor: "text-violet-400",
+  },
+  amber: {
+    border: "border-amber-500/30 hover:border-amber-500/50",
+    bg: "from-amber-500/10 via-amber-500/5 to-transparent hover:from-amber-500/15 hover:via-amber-500/10",
+    icon: "bg-amber-500/20 border-amber-500/30 group-hover:border-amber-500/50 group-hover:bg-amber-500/20",
+    iconColor: "text-amber-400",
+  },
+}
+
+export default function EmailResourcesPage() {
+  return (
+    <div className="space-y-12">
+      {/* Header */}
+      <section className="space-y-4">
+        <h1 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+          Resources
+        </h1>
+        <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
+          Tools from the Marketing Toolkit to help you create and review content.
+        </p>
+      </section>
+
+      {/* Marketing Toolkit Links */}
+      <section className="space-y-6">
+        <h2 className="text-xl font-semibold text-foreground">Marketing Toolkit</h2>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {tools.map((tool) => {
+            const colors = colorClasses[tool.color as keyof typeof colorClasses]
+            return (
+              <Link
+                key={tool.title}
+                href={tool.url}
+                className={`group relative flex items-center justify-between gap-4 rounded-xl border bg-gradient-to-r p-5 transition-all ${colors.border} ${colors.bg}`}
+              >
+                <div className="space-y-1.5">
+                  <h3 className="text-base font-semibold text-foreground">
+                    {tool.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    {tool.description}
+                  </p>
+                </div>
+                <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full border transition-all ${colors.icon}`}>
+                  <ArrowUpRight className={`h-5 w-5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5 ${colors.iconColor}`} />
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,7 +7,8 @@ import {
   ScanSearch,
   QrCode,
   Sparkles,
-  Mail
+  Mail,
+  BookOpen
 } from 'lucide-react'
 
 const tools = [
@@ -73,6 +74,14 @@ const tools = [
     title: 'SOQL Query Helper',
     description: 'Generate and test Salesforce SOQL queries',
     color: 'from-pink-500/40 to-pink-500/40 hover:from-pink-500/50 hover:to-pink-500/50 dark:from-pink-300/20 dark:to-pink-300/20 dark:hover:from-pink-300/30 dark:hover:to-pink-300/30',
+    lightText: false
+  },
+  {
+    href: '/email-guidelines',
+    icon: BookOpen,
+    title: 'Email Guidelines',
+    description: 'Voice, tone, and formatting standards for marketing emails',
+    color: 'from-indigo-500/40 to-indigo-500/40 hover:from-indigo-500/50 hover:to-indigo-500/50 dark:from-indigo-300/20 dark:to-indigo-300/20 dark:hover:from-indigo-300/30 dark:hover:to-indigo-300/30',
     lightText: false
   },
 ]

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -14,6 +14,7 @@ const navItems = [
   { href: '/content-analyzer', label: 'Content' },
   { href: '/email-review', label: 'Email Review' },
   { href: '/soql-query-helper', label: 'Data Tools' },
+  { href: '/email-guidelines', label: 'Guidelines' },
 ]
 
 export default function Navigation() {

--- a/src/components/docs/copy-button.tsx
+++ b/src/components/docs/copy-button.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { useState } from "react"
+import { Check, Copy } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface CopyButtonProps {
+  text: string
+  className?: string
+  label?: string
+}
+
+export function CopyButton({ text, className, label = "Copy" }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch (err) {
+      console.error("Failed to copy:", err)
+    }
+  }
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={handleCopy}
+      className={cn(
+        "h-8 gap-2 text-muted-foreground hover:text-foreground",
+        className
+      )}
+      aria-label={copied ? "Copied" : label}
+      suppressHydrationWarning
+    >
+      <span className="flex items-center gap-2" suppressHydrationWarning>
+        {copied ? (
+          <>
+            <Check className="h-4 w-4 text-green-500" aria-hidden="true" />
+            <span>Copied!</span>
+          </>
+        ) : (
+          <>
+            <Copy className="h-4 w-4" aria-hidden="true" />
+            <span>{label}</span>
+          </>
+        )}
+      </span>
+    </Button>
+  )
+}

--- a/src/components/docs/copy-card.tsx
+++ b/src/components/docs/copy-card.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { CopyButton } from "./copy-button"
+import { cn } from "@/lib/utils"
+import { Check, X } from "lucide-react"
+
+interface CopyCardProps {
+  title: string
+  content: string
+  variant?: "do" | "dont" | "neutral"
+  className?: string
+  hideCopy?: boolean
+}
+
+export function CopyCard({ title, content, variant = "neutral", className, hideCopy = false }: CopyCardProps) {
+  const variantStyles = {
+    do: "border-l-green-500",
+    dont: "border-l-red-500",
+    neutral: "border-l-border",
+  }
+
+  return (
+    <div
+      className={cn(
+        "rounded-lg border border-border bg-card border-l-4",
+        variantStyles[variant],
+        className
+      )}
+    >
+      <div className="flex items-start justify-between gap-4 p-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2" suppressHydrationWarning>
+            {variant === "do" && (
+              <span className="shrink-0" aria-label="Do" suppressHydrationWarning>
+                <Check className="h-4 w-4 text-green-500" />
+              </span>
+            )}
+            {variant === "dont" && (
+              <span className="shrink-0" aria-label="Don't" suppressHydrationWarning>
+                <X className="h-4 w-4 text-red-500" />
+              </span>
+            )}
+            <h4 className="text-sm font-medium text-foreground">{title}</h4>
+          </div>
+          <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-line">{content}</p>
+        </div>
+        {!hideCopy && <CopyButton text={content} className="shrink-0" />}
+      </div>
+    </div>
+  )
+}

--- a/src/components/docs/sample-panel.tsx
+++ b/src/components/docs/sample-panel.tsx
@@ -1,0 +1,34 @@
+import { cn } from "@/lib/utils"
+
+interface SamplePanelProps {
+  before: string
+  after: string
+  title?: string
+  className?: string
+}
+
+export function SamplePanel({ before, after, title, className }: SamplePanelProps) {
+  return (
+    <div className={cn("rounded-lg border border-border bg-card overflow-hidden", className)}>
+      {title && (
+        <div className="border-b border-border px-4 py-3 bg-muted">
+          <h4 className="text-sm font-medium text-foreground">{title}</h4>
+        </div>
+      )}
+      <div className="grid gap-0 divide-y divide-border md:grid-cols-2 md:divide-x md:divide-y-0">
+        <div className="p-4">
+          <div className="mb-3">
+            <span className="text-xs font-semibold uppercase tracking-wide text-red-500">Before</span>
+          </div>
+          <p className="text-sm text-muted-foreground leading-relaxed">{before}</p>
+        </div>
+        <div className="p-4">
+          <div className="mb-3">
+            <span className="text-xs font-semibold uppercase tracking-wide text-green-500">After</span>
+          </div>
+          <p className="text-sm text-foreground leading-relaxed">{after}</p>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

This PR incorporates the email guidelines content from the marketing-email-guidelines project into the marketing toolkit.

### Changes

- **Voice & Tone Guidelines** (`/email-guidelines`): Writing style guidelines including sentence length, active voice, positive phrasing, and more
- **Email Formatting** (`/email-guidelines/formatting`): Standards for subject lines, pre-headers, job titles, dates/times, images, bullet points, and signatures
- **Examples** (`/email-guidelines/examples`): Real email examples demonstrating proper formatting
- **Resources** (`/email-guidelines/resources`): Links to other marketing toolkit tools

### Home Page

Added a new card for 'Email Guidelines' on the home page to make the documentation easily discoverable.

### Navigation

Includes a responsive navigation header with links to all sections, with a back arrow to return to the main toolkit.