### PR TITLE
feat: add location field to calendar link generator

### DIFF
--- a/src/app/date-time-picker/page.tsx
+++ b/src/app/date-time-picker/page.tsx
@@ -60,6 +60,7 @@ export default function EventCreatorPage() {
   // --- STATE MANAGEMENT ---
   const [eventName, setEventName] = useState("")
   const [description, setDescription] = useState("")
+  const [location, setLocation] = useState("")
   const [date, setDate] = useState<Date>()
   const [hour, setHour] = useState("10")
   const [minute, setMinute] = useState("00")
@@ -224,9 +225,10 @@ export default function EventCreatorPage() {
 
     const encodedEventName = encodeURIComponent(eventName)
     const encodedDescription = encodeURIComponent(description)
+    const encodedLocation = encodeURIComponent(location)
 
-    const googleLink = `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodedEventName}&dates=${startUtcFormatted}/${endUtcFormatted}&details=${encodedDescription}&ctz=${timezone}`
-    const agicalLink = `https://ics.agical.io/?dtstart=${toAgicalFormat(startUtc)}&dtend=${toAgicalFormat(endUtc)}&subject=${encodedEventName}&description=${encodedDescription}`
+    const googleLink = `https://www.google.com/calendar/render?action=TEMPLATE&text=${encodedEventName}&dates=${startUtcFormatted}/${endUtcFormatted}&details=${encodedDescription}&location=${encodedLocation}&ctz=${timezone}`
+    const agicalLink = `https://ics.agical.io/?dtstart=${toAgicalFormat(startUtc)}&dtend=${toAgicalFormat(endUtc)}&subject=${encodedEventName}&description=${encodedDescription}&location=${encodedLocation}`
     const formattedDateTime = formatDate(startUtc, customFormat, timezone)
 
     setGeneratedOutput({
@@ -428,6 +430,18 @@ export default function EventCreatorPage() {
                       className="bg-card border-input text-foreground placeholder:text-muted-foreground mt-1"
                       placeholder="e.g., The body of the invite (venue info, links, etc.)."
                       rows={5}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="location" className="text-muted-foreground text-sm font-medium">
+                      Location
+                    </Label>
+                    <Input
+                      id="location"
+                      value={location}
+                      onChange={(e) => setLocation(e.target.value)}
+                      className="bg-card border-input text-foreground placeholder:text-muted-foreground mt-1"
+                      placeholder="e.g., 123 Main St, San Francisco, CA"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## What

Adds a **Location** input to the calendar event creator (`/date-time-picker`) and appends a `&location=` parameter to both generated links:

- **Google Calendar** (`google.com/calendar/render`) — populates the native Location field
- **agical.io ICS** (`ics.agical.io`) — writes the ICS `LOCATION:` property, so Apple Calendar / Outlook place it in the right spot too

## Why

Per the Slack thread: calendar links currently have no location, forcing it into the description. This puts the address in the proper location field on each platform.

## Changes

- New `location` state + form input (under Description in Event Details)
- Append `&location=${encodeURIComponent(location)}` to both link builders (same encoding as the other fields — spaces become `%20`)

## Testing

- `npx tsc --noEmit` passes
- Manual: fill in a location, generate, confirm the param lands in the correct calendar field on Google and ICS imports

## Note

An empty location produces a harmless trailing `&location=`. Can make it conditional if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)