### PR TITLE
feat: add request PRD generator

### DIFF
--- a/src/app/api/prd/clarify/route.ts
+++ b/src/app/api/prd/clarify/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server"
+import { generateObject } from "ai"
+import { z } from "zod"
+import {
+  PRD_MODELS,
+  buildTriageSystemPrompt,
+  formatIntake,
+  getRequestType,
+  type PrdIntake,
+} from "@/lib/prd-template"
+
+const TriageSchema = z.object({
+  ready: z
+    .boolean()
+    .describe(
+      "True when there is enough specific context to draft a useful PRD."
+    ),
+  questions: z
+    .array(
+      z.object({
+        question: z
+          .string()
+          .describe("A single specific question, answerable in a sentence."),
+        why: z
+          .string()
+          .describe("What you would otherwise have to guess. One short line."),
+      })
+    )
+    .max(3)
+    .describe("Empty when ready is true. Never more than three."),
+})
+
+export async function POST(request: NextRequest) {
+  try {
+    const intake = (await request.json()) as PrdIntake
+
+    if (!intake?.requestType || !getRequestType(intake.requestType)) {
+      return NextResponse.json(
+        { error: "A valid request type is required" },
+        { status: 400 }
+      )
+    }
+
+    if (!intake.brainDump?.trim()) {
+      return NextResponse.json(
+        { error: "Describe what you need before generating" },
+        { status: 400 }
+      )
+    }
+
+    if (!process.env.AI_GATEWAY_API_KEY) {
+      return NextResponse.json(
+        {
+          error:
+            "AI Gateway not configured. Please add AI_GATEWAY_API_KEY to your environment variables.",
+        },
+        { status: 500 }
+      )
+    }
+
+    const { object } = await generateObject({
+      model: PRD_MODELS.triage,
+      schema: TriageSchema,
+      system: buildTriageSystemPrompt(),
+      prompt: formatIntake(intake),
+    })
+
+    // Belt and braces: a "not ready" verdict with no questions would strand the
+    // user on an empty clarify screen, so treat it as ready.
+    const questions = object.ready ? [] : object.questions.slice(0, 3)
+
+    return NextResponse.json({
+      ready: object.ready || questions.length === 0,
+      questions,
+    })
+  } catch (error) {
+    console.error("Error in prd/clarify API:", error)
+    return NextResponse.json(
+      { error: "Could not screen the request. Try generating anyway." },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/prd/draft/route.ts
+++ b/src/app/api/prd/draft/route.ts
@@ -1,0 +1,168 @@
+import { NextRequest, NextResponse } from "next/server"
+import { streamText } from "ai"
+import {
+  PRD_MODELS,
+  buildDraftSystemPrompt,
+  formatIntake,
+  getRequestType,
+  type ClarifyingAnswer,
+  type DraftMode,
+  type PrdIntake,
+} from "@/lib/prd-template"
+
+interface DraftRequest {
+  mode?: DraftMode
+  intake: PrdIntake
+  answers?: ClarifyingAnswer[]
+  /** Required when mode is "refine": the document being revised. */
+  currentMarkdown?: string
+  /** Required when mode is "refine": what to change. */
+  instruction?: string
+}
+
+/**
+ * streamText resolves before the model is actually reached, so wrapping it in a
+ * try/catch catches nothing — a rejected model id surfaces only once the stream
+ * is consumed, by which point the response is already committed and a fallback
+ * is impossible. Pulling the first chunk here forces the error to surface while
+ * we can still retry on another model. The chunk is handed back so it can be
+ * replayed into the response body rather than dropped.
+ */
+async function startStream(
+  model: string,
+  system: string,
+  prompt: string
+): Promise<{
+  iterator: AsyncIterator<string>
+  first: IteratorResult<string>
+}> {
+  const result = streamText({
+    model,
+    system,
+    prompt,
+    // Opus 5 thinks by default and this ceiling covers thinking plus prose, so
+    // it needs real headroom or a long PRD truncates mid-section.
+    maxOutputTokens: 16000,
+  })
+
+  const iterator = result.textStream[Symbol.asyncIterator]()
+  const first = await iterator.next()
+  return { iterator, first }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as DraftRequest
+    const mode: DraftMode = body.mode === "refine" ? "refine" : "draft"
+    const intake = body.intake
+
+    if (!intake?.requestType || !getRequestType(intake.requestType)) {
+      return NextResponse.json(
+        { error: "A valid request type is required" },
+        { status: 400 }
+      )
+    }
+
+    if (!intake.brainDump?.trim()) {
+      return NextResponse.json(
+        { error: "Describe what you need before generating" },
+        { status: 400 }
+      )
+    }
+
+    if (mode === "refine" && !body.currentMarkdown?.trim()) {
+      return NextResponse.json(
+        { error: "There is no draft to refine yet" },
+        { status: 400 }
+      )
+    }
+
+    if (mode === "refine" && !body.instruction?.trim()) {
+      return NextResponse.json(
+        { error: "Describe what you want changed" },
+        { status: 400 }
+      )
+    }
+
+    if (!process.env.AI_GATEWAY_API_KEY) {
+      return NextResponse.json(
+        {
+          error:
+            "AI Gateway not configured. Please add AI_GATEWAY_API_KEY to your environment variables.",
+        },
+        { status: 500 }
+      )
+    }
+
+    const system = buildDraftSystemPrompt(
+      intake.requestType,
+      intake.destination,
+      mode
+    )
+
+    const context = formatIntake(intake, body.answers ?? [])
+
+    const prompt =
+      mode === "refine"
+        ? `Original request context:\n${context}\n\nCurrent PRD:\n${body.currentMarkdown!.trim()}\n\nRevision instruction:\n${body.instruction!.trim()}`
+        : context
+
+    let started: Awaited<ReturnType<typeof startStream>>
+    let usedModel: string = PRD_MODELS.draft
+
+    try {
+      started = await startStream(PRD_MODELS.draft, system, prompt)
+    } catch (primaryError) {
+      console.log(
+        `PRD draft model ${PRD_MODELS.draft} failed, falling back to ${PRD_MODELS.draftFallback}:`,
+        primaryError
+      )
+      started = await startStream(PRD_MODELS.draftFallback, system, prompt)
+      usedModel = PRD_MODELS.draftFallback
+    }
+
+    console.log(`PRD ${mode} streaming from model: ${usedModel}`)
+
+    const { iterator, first } = started
+    const encoder = new TextEncoder()
+
+    const stream = new ReadableStream<Uint8Array>({
+      async start(controller) {
+        try {
+          if (!first.done && first.value) {
+            controller.enqueue(encoder.encode(first.value))
+          }
+          if (!first.done) {
+            while (true) {
+              const next = await iterator.next()
+              if (next.done) break
+              if (next.value) controller.enqueue(encoder.encode(next.value))
+            }
+          }
+          controller.close()
+        } catch (streamError) {
+          console.error("Error while streaming PRD draft:", streamError)
+          controller.error(streamError)
+        }
+      },
+      async cancel() {
+        // The client aborted; stop pulling from the model.
+        await iterator.return?.()
+      },
+    })
+
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Cache-Control": "no-store",
+        "X-Prd-Model": usedModel,
+      },
+    })
+  } catch (error) {
+    console.error("Error in prd/draft API:", error)
+    return NextResponse.json(
+      { error: "Could not generate the PRD. Please try again." },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import {
   CalendarDays,
+  FileText,
   Image,
   LinkIcon,
   MessageSquare,
@@ -11,6 +12,14 @@ import {
 } from 'lucide-react'
 
 const tools = [
+  {
+    href: '/prd-generator',
+    icon: FileText,
+    title: 'Request PRD Generator',
+    description: 'Turn a rough request into a PRD your team can build from',
+    color: 'from-indigo-500/40 to-indigo-500/40 hover:from-indigo-500/50 hover:to-indigo-500/50 dark:from-indigo-300/20 dark:to-indigo-300/20 dark:hover:from-indigo-300/30 dark:hover:to-indigo-300/30',
+    lightText: false
+  },
   {
     href: '/naming-generators',
     icon: MessageSquare,

--- a/src/app/prd-generator/components/PrdGenerator.tsx
+++ b/src/app/prd-generator/components/PrdGenerator.tsx
@@ -1,0 +1,873 @@
+"use client"
+
+import { useCallback, useEffect, useRef, useState } from "react"
+import { saveAs } from "file-saver"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import {
+  AlertCircle,
+  ArrowLeft,
+  Check,
+  Copy,
+  Download,
+  FileText,
+  HelpCircle,
+  Loader2,
+  RotateCcw,
+  Sparkles,
+  StopCircle,
+  Wand2,
+} from "lucide-react"
+import {
+  PRD_DESTINATIONS,
+  REQUEST_TYPES,
+  getRequestType,
+  sectionsFor,
+  type ClarifyingAnswer,
+  type PrdIntake,
+} from "@/lib/prd-template"
+
+const STORAGE_KEY = "prd-generator:v1"
+
+type Phase = "intake" | "clarify" | "draft"
+
+interface Question {
+  question: string
+  why: string
+}
+
+const EMPTY_INTAKE: PrdIntake = {
+  requestType: "",
+  destination: "agent",
+  title: "",
+  brainDump: "",
+  audience: "",
+  outcome: "",
+  targetDate: "",
+  requestingTeam: "",
+  constraints: "",
+  links: "",
+}
+
+function filenameFor(title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60)
+  return `${slug || "prd"}.md`
+}
+
+export default function PrdGenerator() {
+  const [phase, setPhase] = useState<Phase>("intake")
+  const [intake, setIntake] = useState<PrdIntake>(EMPTY_INTAKE)
+  const [showOptional, setShowOptional] = useState(false)
+
+  const [questions, setQuestions] = useState<Question[]>([])
+  const [answers, setAnswers] = useState<string[]>([])
+  const [isScreening, setIsScreening] = useState(false)
+
+  const [markdown, setMarkdown] = useState("")
+  const [isStreaming, setIsStreaming] = useState(false)
+  const [modelUsed, setModelUsed] = useState<string | null>(null)
+  const [versions, setVersions] = useState<string[]>([])
+  const [refineInstruction, setRefineInstruction] = useState("")
+
+  const [error, setError] = useState("")
+  const [copied, setCopied] = useState(false)
+
+  const abortRef = useRef<AbortController | null>(null)
+  const outputRef = useRef<HTMLDivElement | null>(null)
+  const restored = useRef(false)
+
+  const selectedType = getRequestType(intake.requestType)
+  const sections = intake.requestType ? sectionsFor(intake.requestType) : []
+
+  // --- Persistence: survive a refresh without a database ---------------------
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY)
+      if (raw) {
+        const saved = JSON.parse(raw) as {
+          intake?: PrdIntake
+          markdown?: string
+        }
+        if (saved.intake) setIntake({ ...EMPTY_INTAKE, ...saved.intake })
+        if (saved.markdown) {
+          setMarkdown(saved.markdown)
+          setPhase("draft")
+        }
+      }
+    } catch {
+      // Corrupt or unavailable storage is not worth surfacing.
+    }
+    restored.current = true
+  }, [])
+
+  useEffect(() => {
+    if (!restored.current) return
+    try {
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({ intake, markdown })
+      )
+    } catch {
+      // Quota or private mode. Nothing actionable for the user.
+    }
+  }, [intake, markdown])
+
+  // Abort any in-flight generation if the component goes away.
+  useEffect(() => () => abortRef.current?.abort(), [])
+
+  // Follow the stream as it writes.
+  useEffect(() => {
+    if (isStreaming && outputRef.current) {
+      outputRef.current.scrollTop = outputRef.current.scrollHeight
+    }
+  }, [markdown, isStreaming])
+
+  const setField = (key: keyof PrdIntake, value: string) =>
+    setIntake((prev) => ({ ...prev, [key]: value }))
+
+  // --- Generation ------------------------------------------------------------
+
+  const streamDraft = useCallback(
+    async (payload: Record<string, unknown>, previous?: string) => {
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      setError("")
+      setIsStreaming(true)
+      setPhase("draft")
+      setMarkdown("")
+
+      try {
+        const response = await fetch("/api/prd/draft", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+          signal: controller.signal,
+        })
+
+        if (!response.ok) {
+          const data = (await response.json().catch(() => ({}))) as {
+            error?: string
+          }
+          throw new Error(data.error || "Could not generate the PRD.")
+        }
+
+        setModelUsed(response.headers.get("X-Prd-Model"))
+
+        const reader = response.body?.getReader()
+        if (!reader) throw new Error("No response stream from the server.")
+
+        const decoder = new TextDecoder()
+        let accumulated = ""
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          accumulated += decoder.decode(value, { stream: true })
+          setMarkdown(accumulated)
+        }
+
+        accumulated += decoder.decode()
+        setMarkdown(accumulated)
+
+        if (!accumulated.trim()) {
+          throw new Error("The model returned an empty document. Try again.")
+        }
+
+        // Only bank the previous version once the new one actually arrived.
+        if (previous) setVersions((prev) => [...prev, previous])
+      } catch (err) {
+        const aborted = err instanceof Error && err.name === "AbortError"
+
+        // A half-finished refine is a truncated document, and the complete one
+        // it replaced was never banked for undo — so put it back. On a first
+        // draft there is nothing to restore, and a partial is better than none.
+        if (previous) setMarkdown(previous)
+
+        if (aborted) return // The user chose to stop; not an error worth showing.
+
+        setError(
+          err instanceof Error ? err.message : "Could not generate the PRD."
+        )
+      } finally {
+        setIsStreaming(false)
+        abortRef.current = null
+      }
+    },
+    []
+  )
+
+  const handleGenerate = async () => {
+    if (!intake.requestType) {
+      setError("Pick a request type first")
+      return
+    }
+    if (!intake.brainDump.trim()) {
+      setError("Describe what you need before generating")
+      return
+    }
+
+    setError("")
+    setIsScreening(true)
+
+    try {
+      const response = await fetch("/api/prd/clarify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(intake),
+      })
+
+      const data = (await response.json()) as {
+        ready?: boolean
+        questions?: Question[]
+        error?: string
+      }
+
+      if (!response.ok) throw new Error(data.error || "Screening failed.")
+
+      if (!data.ready && data.questions?.length) {
+        setQuestions(data.questions)
+        setAnswers(data.questions.map(() => ""))
+        setPhase("clarify")
+        setIsScreening(false)
+        return
+      }
+
+      setIsScreening(false)
+      await streamDraft({ mode: "draft", intake, answers: [] })
+    } catch (err) {
+      // Screening is a convenience, not a gate. If it fails, still let them draft.
+      setIsScreening(false)
+      setError(
+        err instanceof Error
+          ? `${err.message} You can still generate without it.`
+          : "Screening failed. You can still generate without it."
+      )
+    }
+  }
+
+  const submitAnswers = async () => {
+    const paired: ClarifyingAnswer[] = questions.map((q, i) => ({
+      question: q.question,
+      answer: answers[i] ?? "",
+    }))
+    await streamDraft({ mode: "draft", intake, answers: paired })
+  }
+
+  const handleRefine = async () => {
+    if (!refineInstruction.trim() || !markdown.trim()) return
+    const instruction = refineInstruction.trim()
+    setRefineInstruction("")
+    await streamDraft(
+      {
+        mode: "refine",
+        intake,
+        currentMarkdown: markdown,
+        instruction,
+      },
+      markdown
+    )
+  }
+
+  const handleUndo = () => {
+    setVersions((prev) => {
+      if (prev.length === 0) return prev
+      const last = prev[prev.length - 1]
+      setMarkdown(last)
+      return prev.slice(0, -1)
+    })
+  }
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(markdown).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  const handleDownload = () => {
+    const blob = new Blob([markdown], {
+      type: "text/markdown;charset=utf-8",
+    })
+    saveAs(blob, filenameFor(intake.title))
+  }
+
+  const handleStartOver = () => {
+    abortRef.current?.abort()
+    setPhase("intake")
+    setMarkdown("")
+    setVersions([])
+    setQuestions([])
+    setAnswers([])
+    setModelUsed(null)
+    setError("")
+  }
+
+  const canGenerate =
+    Boolean(intake.requestType) &&
+    intake.brainDump.trim().length > 0 &&
+    !isScreening &&
+    !isStreaming
+
+  // --- Render ----------------------------------------------------------------
+
+  return (
+    <div className="bg-background text-foreground p-4 sm:p-8 flex justify-center pt-16">
+      <Card className="w-full max-w-6xl bg-background border-border">
+        <CardHeader className="p-6 border-b border-border">
+          <CardTitle className="text-foreground text-2xl font-semibold flex items-center gap-2">
+            <FileText className="h-6 w-6 text-[#0070f3]" />
+            Request PRD Generator
+          </CardTitle>
+          <CardDescription className="text-muted-foreground">
+            Turn a rough request into a structured PRD your team — or a coding
+            agent — can build from. Paste the result straight into Notion.
+          </CardDescription>
+        </CardHeader>
+
+        <CardContent className="p-6">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+            {/* ---------------------------------------------------- Left column */}
+            <div className="space-y-4">
+              {phase === "clarify" ? (
+                <ClarifyPanel
+                  questions={questions}
+                  answers={answers}
+                  onChange={(i, value) =>
+                    setAnswers((prev) => {
+                      const next = [...prev]
+                      next[i] = value
+                      return next
+                    })
+                  }
+                  onBack={() => setPhase("intake")}
+                  onSubmit={submitAnswers}
+                  onSkip={() =>
+                    streamDraft({ mode: "draft", intake, answers: [] })
+                  }
+                  busy={isStreaming}
+                />
+              ) : (
+                <>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="request-type"
+                        className="text-muted-foreground text-sm font-medium"
+                      >
+                        Request type
+                      </Label>
+                      <Select
+                        value={intake.requestType}
+                        onValueChange={(value) =>
+                          setField("requestType", value)
+                        }
+                      >
+                        <SelectTrigger
+                          id="request-type"
+                          className="bg-card border-input text-foreground"
+                        >
+                          <SelectValue placeholder="What are you requesting?" />
+                        </SelectTrigger>
+                        <SelectContent className="bg-card border-input text-foreground">
+                          {REQUEST_TYPES.map((type) => (
+                            <SelectItem key={type.id} value={type.id}>
+                              {type.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label
+                        htmlFor="destination"
+                        className="text-muted-foreground text-sm font-medium"
+                      >
+                        Who is this for?
+                      </Label>
+                      <Select
+                        value={intake.destination}
+                        onValueChange={(value) =>
+                          setField("destination", value)
+                        }
+                      >
+                        <SelectTrigger
+                          id="destination"
+                          className="bg-card border-input text-foreground"
+                        >
+                          <SelectValue placeholder="Who receives this PRD?" />
+                        </SelectTrigger>
+                        <SelectContent className="bg-card border-input text-foreground">
+                          {PRD_DESTINATIONS.map((d) => (
+                            <SelectItem key={d.id} value={d.id}>
+                              {d.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="title"
+                      className="text-muted-foreground text-sm font-medium"
+                    >
+                      Working title
+                    </Label>
+                    <Input
+                      id="title"
+                      value={intake.title}
+                      onChange={(e) => setField("title", e.target.value)}
+                      placeholder="Meeting booking app"
+                      className="bg-card border-input text-foreground"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label
+                      htmlFor="brain-dump"
+                      className="text-muted-foreground text-sm font-medium"
+                    >
+                      What do you need, and why?
+                    </Label>
+                    <Textarea
+                      id="brain-dump"
+                      value={intake.brainDump}
+                      onChange={(e) => setField("brainDump", e.target.value)}
+                      placeholder={
+                        selectedType?.placeholder ??
+                        "Describe what you want, who it is for, and what outcome it should drive. Plain language is fine."
+                      }
+                      rows={10}
+                      className="bg-card border-input text-foreground placeholder:text-muted-foreground resize-none"
+                    />
+                    <p className="text-muted-foreground text-xs">
+                      {intake.brainDump.length} characters. The more specific
+                      you are, the fewer questions you&apos;ll get asked.
+                    </p>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => setShowOptional((v) => !v)}
+                    className="text-sm text-muted-foreground hover:text-foreground transition-colors underline underline-offset-4"
+                  >
+                    {showOptional ? "Hide" : "Add"} optional detail
+                  </button>
+
+                  {showOptional && (
+                    <div className="space-y-4 rounded-md border border-border bg-card/50 p-4">
+                      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div className="space-y-2">
+                          <Label
+                            htmlFor="audience"
+                            className="text-muted-foreground text-sm font-medium"
+                          >
+                            Audience or users
+                          </Label>
+                          <Input
+                            id="audience"
+                            value={intake.audience}
+                            onChange={(e) =>
+                              setField("audience", e.target.value)
+                            }
+                            placeholder="AEs and inbound prospects"
+                            className="bg-card border-input text-foreground"
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label
+                            htmlFor="outcome"
+                            className="text-muted-foreground text-sm font-medium"
+                          >
+                            Desired outcome
+                          </Label>
+                          <Input
+                            id="outcome"
+                            value={intake.outcome}
+                            onChange={(e) =>
+                              setField("outcome", e.target.value)
+                            }
+                            placeholder="Cut time-to-meeting from days to minutes"
+                            className="bg-card border-input text-foreground"
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label
+                            htmlFor="target-date"
+                            className="text-muted-foreground text-sm font-medium"
+                          >
+                            Target date
+                          </Label>
+                          <Input
+                            id="target-date"
+                            value={intake.targetDate}
+                            onChange={(e) =>
+                              setField("targetDate", e.target.value)
+                            }
+                            placeholder="End of Q3"
+                            className="bg-card border-input text-foreground"
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <Label
+                            htmlFor="team"
+                            className="text-muted-foreground text-sm font-medium"
+                          >
+                            Requesting team
+                          </Label>
+                          <Input
+                            id="team"
+                            value={intake.requestingTeam}
+                            onChange={(e) =>
+                              setField("requestingTeam", e.target.value)
+                            }
+                            placeholder="Marketing Ops"
+                            className="bg-card border-input text-foreground"
+                          />
+                        </div>
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label
+                          htmlFor="constraints"
+                          className="text-muted-foreground text-sm font-medium"
+                        >
+                          Known constraints
+                        </Label>
+                        <Textarea
+                          id="constraints"
+                          value={intake.constraints}
+                          onChange={(e) =>
+                            setField("constraints", e.target.value)
+                          }
+                          placeholder="Must use Google Calendar. No new vendor contracts. Has to work on mobile."
+                          rows={2}
+                          className="bg-card border-input text-foreground placeholder:text-muted-foreground resize-none"
+                        />
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label
+                          htmlFor="links"
+                          className="text-muted-foreground text-sm font-medium"
+                        >
+                          Reference links
+                        </Label>
+                        <Textarea
+                          id="links"
+                          value={intake.links}
+                          onChange={(e) => setField("links", e.target.value)}
+                          placeholder="Competitor example, an existing doc, a design file"
+                          rows={2}
+                          className="bg-card border-input text-foreground placeholder:text-muted-foreground resize-none"
+                        />
+                      </div>
+                    </div>
+                  )}
+
+                  <Button
+                    onClick={handleGenerate}
+                    disabled={!canGenerate}
+                    className="w-full bg-[#0070f3] hover:bg-[#0060df] text-white h-12 text-base font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    {isScreening ? (
+                      <>
+                        <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                        Checking your request...
+                      </>
+                    ) : isStreaming ? (
+                      <>
+                        <Sparkles className="mr-2 h-5 w-5 animate-pulse" />
+                        Writing...
+                      </>
+                    ) : (
+                      <>
+                        <Sparkles className="mr-2 h-5 w-5" />
+                        Generate PRD
+                      </>
+                    )}
+                  </Button>
+
+                  {sections.length > 0 && (
+                    <div className="space-y-2 pt-2">
+                      <Label className="text-muted-foreground text-sm font-medium">
+                        You&apos;ll get {sections.length} sections
+                      </Label>
+                      <div className="flex flex-wrap gap-1.5">
+                        {sections.map((section) => (
+                          <span
+                            key={section.title}
+                            className="text-xs px-2 py-1 rounded-md border border-border bg-card/50 text-muted-foreground"
+                          >
+                            {section.title}
+                          </span>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+
+              {error && (
+                <div className="flex items-start gap-2 p-3 bg-red-950/50 border border-red-900 rounded-md">
+                  <AlertCircle className="h-5 w-5 text-red-500 flex-shrink-0 mt-0.5" />
+                  <p className="text-red-400 text-sm">{error}</p>
+                </div>
+              )}
+            </div>
+
+            {/* --------------------------------------------------- Right column */}
+            <div className="space-y-4">
+              <div className="flex items-center justify-between h-9">
+                <Label className="text-muted-foreground text-sm font-medium">
+                  {isStreaming ? "Writing your PRD..." : "Your PRD"}
+                </Label>
+                {isStreaming && (
+                  <Button
+                    onClick={() => abortRef.current?.abort()}
+                    variant="ghost"
+                    size="sm"
+                    className="text-muted-foreground hover:text-foreground h-8"
+                  >
+                    <StopCircle className="mr-1.5 h-4 w-4" />
+                    Stop
+                  </Button>
+                )}
+              </div>
+
+              <div
+                ref={outputRef}
+                className="w-full rounded-md border border-input bg-card/50 p-4 overflow-y-auto h-[520px]"
+              >
+                {markdown ? (
+                  <pre className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-foreground">
+                    {markdown}
+                    {isStreaming && (
+                      <span className="inline-block w-2 h-3.5 -mb-0.5 bg-[#0070f3] animate-pulse" />
+                    )}
+                  </pre>
+                ) : (
+                  <div className="h-full flex flex-col items-center justify-center text-center gap-2 px-6">
+                    <FileText className="h-8 w-8 text-muted-foreground/40" />
+                    <p className="text-muted-foreground text-sm">
+                      Your PRD will appear here as it&apos;s written.
+                    </p>
+                    <p className="text-muted-foreground/70 text-xs">
+                      Markdown, ready to paste into Notion, Linear, or Docs.
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {markdown && !isStreaming && (
+                <div className="space-y-3">
+                  <div className="grid grid-cols-2 gap-2">
+                    <Button
+                      onClick={handleCopy}
+                      className="bg-[#0070f3] hover:bg-[#0060df] text-white"
+                    >
+                      {copied ? (
+                        <>
+                          <Check className="mr-2 h-4 w-4" /> Copied
+                        </>
+                      ) : (
+                        <>
+                          <Copy className="mr-2 h-4 w-4" /> Copy for Notion
+                        </>
+                      )}
+                    </Button>
+                    <Button
+                      onClick={handleDownload}
+                      variant="outline"
+                      className="border-input hover:bg-accent text-foreground"
+                    >
+                      <Download className="mr-2 h-4 w-4" /> Download .md
+                    </Button>
+                  </div>
+
+                  <p className="text-muted-foreground text-xs">
+                    Paste into Notion and it converts to real headings, lists,
+                    and tables. Works the same in Linear and Google Docs.
+                  </p>
+
+                  <div className="space-y-2 pt-2 border-t border-border">
+                    <Label
+                      htmlFor="refine"
+                      className="text-muted-foreground text-sm font-medium"
+                    >
+                      Refine it
+                    </Label>
+                    <Textarea
+                      id="refine"
+                      value={refineInstruction}
+                      onChange={(e) => setRefineInstruction(e.target.value)}
+                      placeholder="Tighten the scope section. Add more detail on how we'd measure success."
+                      rows={2}
+                      className="bg-card border-input text-foreground placeholder:text-muted-foreground resize-none"
+                    />
+                    <div className="flex gap-2">
+                      <Button
+                        onClick={handleRefine}
+                        disabled={!refineInstruction.trim()}
+                        variant="outline"
+                        className="flex-1 border-input hover:bg-accent text-foreground disabled:opacity-50"
+                      >
+                        <Wand2 className="mr-2 h-4 w-4" /> Apply
+                      </Button>
+                      {versions.length > 0 && (
+                        <Button
+                          onClick={handleUndo}
+                          variant="outline"
+                          className="border-input hover:bg-accent text-foreground"
+                          title="Revert the last refinement"
+                        >
+                          <RotateCcw className="mr-2 h-4 w-4" /> Undo
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex items-center justify-between pt-2">
+                    <Button
+                      onClick={handleStartOver}
+                      variant="ghost"
+                      size="sm"
+                      className="text-muted-foreground hover:text-foreground px-0"
+                    >
+                      <ArrowLeft className="mr-1.5 h-4 w-4" /> Start over
+                    </Button>
+                    {modelUsed && (
+                      <span className="text-muted-foreground/60 text-xs font-mono">
+                        {modelUsed}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// --- Clarify phase ----------------------------------------------------------
+
+function ClarifyPanel({
+  questions,
+  answers,
+  onChange,
+  onBack,
+  onSubmit,
+  onSkip,
+  busy,
+}: {
+  questions: Question[]
+  answers: string[]
+  onChange: (index: number, value: string) => void
+  onBack: () => void
+  onSubmit: () => void
+  onSkip: () => void
+  busy: boolean
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-2 p-3 rounded-md border border-border bg-card/50">
+        <HelpCircle className="h-5 w-5 text-[#0070f3] flex-shrink-0 mt-0.5" />
+        <div className="space-y-1">
+          <p className="text-foreground text-sm font-medium">
+            A few things would make this PRD much better
+          </p>
+          <p className="text-muted-foreground text-xs">
+            Answer what you can. Anything you skip becomes an open question in
+            the document rather than a guess.
+          </p>
+        </div>
+      </div>
+
+      {questions.map((q, i) => (
+        <div key={i} className="space-y-2">
+          <Label
+            htmlFor={`answer-${i}`}
+            className="text-foreground text-sm font-medium"
+          >
+            {q.question}
+          </Label>
+          <p className="text-muted-foreground text-xs">{q.why}</p>
+          <Textarea
+            id={`answer-${i}`}
+            value={answers[i] ?? ""}
+            onChange={(e) => onChange(i, e.target.value)}
+            rows={3}
+            className="bg-card border-input text-foreground placeholder:text-muted-foreground resize-none"
+          />
+        </div>
+      ))}
+
+      <div className="space-y-2">
+        <Button
+          onClick={onSubmit}
+          disabled={busy}
+          className="w-full bg-[#0070f3] hover:bg-[#0060df] text-white h-12 text-base font-medium disabled:opacity-50"
+        >
+          {busy ? (
+            <>
+              <Sparkles className="mr-2 h-5 w-5 animate-pulse" />
+              Writing...
+            </>
+          ) : (
+            <>
+              <Sparkles className="mr-2 h-5 w-5" />
+              Generate PRD
+            </>
+          )}
+        </Button>
+        <div className="flex items-center justify-between">
+          <Button
+            onClick={onBack}
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            className="text-muted-foreground hover:text-foreground px-0"
+          >
+            <ArrowLeft className="mr-1.5 h-4 w-4" /> Edit request
+          </Button>
+          <Button
+            onClick={onSkip}
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            className="text-muted-foreground hover:text-foreground px-0"
+          >
+            Skip and draft anyway
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/prd-generator/page.tsx
+++ b/src/app/prd-generator/page.tsx
@@ -1,0 +1,11 @@
+import PrdGenerator from "./components/PrdGenerator"
+
+export const metadata = {
+  title: "Request PRD Generator",
+  description:
+    "Turn a rough request into a structured PRD your team or a coding agent can build from.",
+}
+
+export default function PrdGeneratorPage() {
+  return <PrdGenerator />
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react'
 import { Menu, X } from 'lucide-react'
 
 const navItems = [
+  { href: '/prd-generator', label: 'PRD' },
   { href: '/naming-generators', label: 'Naming' },
   { href: '/date-time-picker', label: 'Date & Time' },
   { href: '/utm-generator', label: 'UTM' },

--- a/src/lib/prd-template.ts
+++ b/src/lib/prd-template.ts
@@ -1,0 +1,655 @@
+import { VERCEL_WRITING_RULES_BRIEF } from "@/lib/vercel-style-guide"
+
+/**
+ * The PRD template, as config.
+ *
+ * Two families share one engine: marketing requests (campaigns, pages, emails)
+ * and app/product requests (new tools, features, integrations). A request type
+ * picks a family and adds its own sections on top. Adding a type is a config
+ * entry, not new code.
+ */
+
+export const PRD_MODELS = {
+  /** Cheap classification: is there enough context to draft from? */
+  triage: "anthropic/claude-haiku-4-5",
+  /** Long-form drafting. Output quality here gates the whole tool. */
+  draft: "anthropic/claude-opus-5",
+  /** Proven through the gateway in this repo, if the primary is unavailable. */
+  draftFallback: "anthropic/claude-sonnet-4-6",
+} as const
+
+// --- Sections ---------------------------------------------------------------
+
+export interface Section {
+  title: string
+  /** What belongs in the section. Goes into the prompt verbatim. */
+  guidance: string
+}
+
+const MARKETING_SECTIONS: Section[] = [
+  {
+    title: "Summary",
+    guidance:
+      "Two or three sentences: what is being asked for, and why now. Someone should be able to read only this and know whether the request concerns them.",
+  },
+  {
+    title: "Background & context",
+    guidance:
+      "What prompted this request. Prior work, the trigger event, what has already been tried.",
+  },
+  {
+    title: "Objective",
+    guidance:
+      "The business outcome, not the deliverable. 'Increase partner-sourced pipeline', not 'ship a landing page'. If the requester only described a deliverable, infer the likely outcome and label it as an assumption.",
+  },
+  {
+    title: "Success metrics",
+    guidance:
+      "Primary metric, target, current baseline, and how it will be measured. If any of these were not provided, write 'TBD — needs input from <role>'. Never invent a number.",
+  },
+  {
+    title: "Target audience",
+    guidance:
+      "Who this is for: segment, funnel stage, rough size, and where they are today.",
+  },
+  {
+    title: "Scope",
+    guidance:
+      "Two labelled lists: 'In scope' and 'Explicitly out of scope'. The out-of-scope list is the most valuable part of this document — populate it even if the requester did not mention limits, drawing the obvious adjacent asks that are NOT included.",
+  },
+  {
+    title: "Requirements",
+    guidance:
+      "Numbered, testable statements of what must exist. Each one should be verifiable as done or not done.",
+  },
+  {
+    title: "Messaging & content direction",
+    guidance:
+      "Key message, supporting proof points, tone, and the call to action.",
+  },
+  {
+    title: "Channels & deliverables",
+    guidance:
+      "Every asset needed, by channel, with format and specs where known.",
+  },
+  {
+    title: "Dependencies & inputs needed",
+    guidance:
+      "Who owes what before this can ship: legal or brand review, a data pull, design, dev, budget approval. Name the role for each.",
+  },
+  {
+    title: "Timeline & milestones",
+    guidance:
+      "Worked backward from the launch date. If no date was given, say so rather than inventing one.",
+  },
+  {
+    title: "Risks & mitigations",
+    guidance: "What could derail this, and the mitigation for each.",
+  },
+  {
+    title: "Stakeholders & approvals",
+    guidance:
+      "DACI: Driver, Approver, Contributors, Informed. Use roles where names were not given.",
+  },
+  {
+    title: "Open questions & assumptions",
+    guidance:
+      "Every unknown, as a question addressed to a named role. Every assumption you made while drafting. This section absorbs anything you could not answer — nothing above should be left vague because it landed here.",
+  },
+]
+
+const PRODUCT_SECTIONS: Section[] = [
+  {
+    title: "Summary",
+    guidance:
+      "Two or three sentences: what is being built, for whom, and why now.",
+  },
+  {
+    title: "Problem & context",
+    guidance:
+      "Who is hurting and how, plus the current workaround. Be concrete about the cost of the status quo.",
+  },
+  {
+    title: "Objective & success criteria",
+    guidance:
+      "The outcome this should produce, with a metric, a target, and how it will be measured. If those were not provided, write 'TBD — needs input from <role>'. Never invent a number.",
+  },
+  {
+    title: "Users & primary use cases",
+    guidance:
+      "Each distinct user type, and the job each one is doing. For an internal tool, that may be two or three roles with very different needs.",
+  },
+  {
+    title: "Scope",
+    guidance:
+      "Two labelled lists: 'In scope for v1' and 'Explicitly out of scope'. Push anything not needed to prove the concept into out of scope, and say which of those are v2 candidates.",
+  },
+  {
+    title: "User stories & acceptance criteria",
+    guidance:
+      "The core of this document. For each story: 'As a <user>, I want <capability>, so that <outcome>.' Under each, acceptance criteria as Given / When / Then bullets. Cover the unhappy paths too — double booking, cancellation, a timezone mismatch, an expired link. A developer should be able to build and test from these alone.",
+  },
+  {
+    title: "Functional requirements",
+    guidance:
+      "Numbered, testable statements of system behavior that the user stories do not already cover.",
+  },
+  {
+    title: "Screens & key flows",
+    guidance:
+      "Screen by screen. For each: purpose, the key elements on it, and its empty, loading, error, and success states. Then the primary end-to-end flow as a numbered sequence.",
+  },
+  {
+    title: "Data model",
+    guidance:
+      "Each entity with its fields, types, and relationships. Note required versus optional, and anything that needs to be unique. A table per entity works well here.",
+  },
+  {
+    title: "Integrations & external services",
+    guidance:
+      "Every external system: auth provider, calendar API, email or SMS, payments, analytics. For each, what it is used for and what data crosses the boundary.",
+  },
+  {
+    title: "Non-functional requirements",
+    guidance:
+      "Authentication and permissions (who can see and do what), performance expectations, accessibility, mobile and responsive behavior, and any data retention or privacy constraint.",
+  },
+  {
+    title: "Technical constraints & preferences",
+    guidance:
+      "Required or preferred stack, hosting, and existing systems it must fit. Also what NOT to use. If the requester stated no preference, say so — do not silently pick for them.",
+  },
+  {
+    title: "Risks & open questions",
+    guidance:
+      "Technical and product risks with mitigations, plus every unknown as a question addressed to a named role.",
+  },
+  {
+    title: "Milestones & phasing",
+    guidance:
+      "v1 as the smallest thing that proves the concept, then what follows. Include a target date only if one was given.",
+  },
+  {
+    title: "Stakeholders & approvals",
+    guidance:
+      "Who requested it, who decides it is done, who contributes, who needs to be told. Use roles where names were not given.",
+  },
+]
+
+export const TEMPLATE_FAMILIES = {
+  marketing: { label: "Marketing request", sections: MARKETING_SECTIONS },
+  product: { label: "App / product request", sections: PRODUCT_SECTIONS },
+} as const
+
+export type FamilyId = keyof typeof TEMPLATE_FAMILIES
+
+// --- Request types ----------------------------------------------------------
+
+export interface RequestType {
+  id: string
+  label: string
+  family: FamilyId
+  /** Type-specific emphasis for the drafting model. */
+  guidance: string
+  /** Sections appended after the family's base set. */
+  extraSections: Section[]
+  /** Shown in the intake form as the brain-dump placeholder. */
+  placeholder: string
+}
+
+export const REQUEST_TYPES: RequestType[] = [
+  {
+    id: "app",
+    label: "New app or tool",
+    family: "product",
+    guidance:
+      "A net-new application. Be explicit about the accounts model and the first-run experience, since those are the details requesters most often leave out.",
+    extraSections: [
+      {
+        title: "Accounts & auth model",
+        guidance:
+          "Who has an account, how they sign in, what roles exist, and whether anything is accessible without signing in.",
+      },
+      {
+        title: "Onboarding flow",
+        guidance:
+          "What a brand-new user does between first arrival and first success. Name the first-run empty state.",
+      },
+    ],
+    placeholder:
+      "Example: We need a meeting booking app so prospects can self-schedule with our AEs instead of emailing back and forth. AEs connect their Google Calendar, set weekly availability, and get a shareable link. Prospects pick a slot, enter their name, email and company, and both sides get a calendar invite and a confirmation email.",
+  },
+  {
+    id: "feature",
+    label: "Feature in an existing app",
+    family: "product",
+    guidance:
+      "An addition to something already running. Describe current behavior before new behavior, and be explicit about existing users and data.",
+    extraSections: [
+      {
+        title: "Current behavior",
+        guidance:
+          "How it works today, precisely enough that the delta is unambiguous.",
+      },
+      {
+        title: "Migration & backfill",
+        guidance:
+          "What happens to existing records, and whether a backfill or migration is needed.",
+      },
+      {
+        title: "Impact on existing users",
+        guidance:
+          "What changes for people already using this, whether anything breaks, and what they need to be told.",
+      },
+    ],
+    placeholder:
+      "Example: Add saved views to the campaign dashboard. Today everyone re-applies the same filters every morning. Users should be able to name a filter set, pin it, and share it with their team.",
+  },
+  {
+    id: "integration",
+    label: "Integration or automation",
+    family: "product",
+    guidance:
+      "Systems talking to each other. Direction of data flow and failure behavior matter more than UI here.",
+    extraSections: [
+      {
+        title: "Trigger & schedule",
+        guidance:
+          "What starts it: a user action, a webhook, or a schedule. If scheduled, how often and in which timezone.",
+      },
+      {
+        title: "Systems & data flow",
+        guidance:
+          "Each system, the direction data moves, the fields mapped, and which side is the source of truth.",
+      },
+      {
+        title: "Failure & retry behavior",
+        guidance:
+          "What happens on a failed sync: retries, alerting, and whether partial success is acceptable.",
+      },
+    ],
+    placeholder:
+      "Example: Sync form fills from our landing pages into Salesforce as leads, with UTM parameters mapped to campaign fields. Should be near real time and must not create duplicates for known contacts.",
+  },
+  {
+    id: "campaign",
+    label: "Campaign",
+    family: "marketing",
+    guidance:
+      "A multi-channel push. Be concrete about the offer and how spend is allocated.",
+    extraSections: [
+      {
+        title: "Budget & spend",
+        guidance: "Total budget and allocation by channel, if provided.",
+      },
+      {
+        title: "Offer & CTA",
+        guidance:
+          "The specific offer, the action being asked for, and where it lands.",
+      },
+    ],
+    placeholder:
+      "Example: Q3 push to get more partner-sourced pipeline. Email to our partner list, a co-branded landing page, and paid social. Aimed at platform engineering leads at mid-market companies already using a competitor.",
+  },
+  {
+    id: "launch",
+    label: "Product launch / GTM",
+    family: "marketing",
+    guidance:
+      "A launch. Positioning and enablement carry the most weight; be explicit about launch tier.",
+    extraSections: [
+      {
+        title: "Positioning & differentiation",
+        guidance:
+          "What this is, who it is for, and why it wins against the alternative including doing nothing.",
+      },
+      {
+        title: "Launch tier",
+        guidance:
+          "The tier and what that entails, from a changelog entry through to a full moment.",
+      },
+      {
+        title: "Enablement needs",
+        guidance:
+          "What sales, support, and partners need before launch day: talk tracks, docs, demo, FAQ, pricing guidance.",
+      },
+    ],
+    placeholder:
+      "Example: Launching the new observability dashboard in six weeks. Needs a blog post, docs, changelog, a demo video, and a sales one-pager. Aimed at existing Pro customers first.",
+  },
+  {
+    id: "email",
+    label: "Email / lifecycle",
+    family: "marketing",
+    guidance:
+      "Email or a lifecycle program. Segmentation, suppression, and compliance are where these go wrong.",
+    extraSections: [
+      {
+        title: "Segment & suppression logic",
+        guidance:
+          "Exactly who receives this and who must be excluded, as stated criteria.",
+      },
+      {
+        title: "Send schedule & cadence",
+        guidance:
+          "Dates, times, timezone handling, and the sequence if there is more than one send.",
+      },
+      {
+        title: "Deliverability & compliance",
+        guidance:
+          "Unsubscribe and preference handling, consent basis, and any regional requirement.",
+      },
+    ],
+    placeholder:
+      "Example: Three-email onboarding sequence for new self-serve signups who have not deployed yet. Goal is a first deploy within seven days. Should stop sending as soon as they deploy.",
+  },
+  {
+    id: "web",
+    label: "Web page or landing page",
+    family: "marketing",
+    guidance:
+      "A page. URL, information architecture placement, SEO, and tracking are the details most often missing.",
+    extraSections: [
+      {
+        title: "URL & IA placement",
+        guidance:
+          "The proposed URL, where it sits in navigation, and what links to it.",
+      },
+      {
+        title: "SEO",
+        guidance:
+          "Target keywords, title and meta description direction, and any redirect needed.",
+      },
+      {
+        title: "Tracking & UTM plan",
+        guidance:
+          "Conversion events to instrument and the UTM convention for inbound links.",
+      },
+    ],
+    placeholder:
+      "Example: Landing page for the AI Accelerate event. Needs registration, agenda, speakers, and a post-event state that swaps in the recording.",
+  },
+  {
+    id: "event",
+    label: "Event or webinar",
+    family: "marketing",
+    guidance:
+      "An event. Logistics and the follow-up motion matter as much as promotion — most of the value is in what happens after.",
+    extraSections: [
+      {
+        title: "Logistics",
+        guidance:
+          "Venue or platform, date and time with timezone, capacity, and run of show.",
+      },
+      {
+        title: "Registration & promotion",
+        guidance:
+          "Registration flow, promotional channels and timing, and reminder sends.",
+      },
+      {
+        title: "Follow-up motion",
+        guidance:
+          "What happens to attendees and to no-shows, who follows up, and by when.",
+      },
+    ],
+    placeholder:
+      "Example: Technical webinar on shipping AI apps, aimed at platform teams. Want 500 registrations and 40% attendance. Recording becomes gated content afterward.",
+  },
+  {
+    id: "content",
+    label: "Content asset",
+    family: "marketing",
+    guidance:
+      "A content piece. Be explicit about format, the review path, and how it gets distributed — an asset nobody sees is the common failure.",
+    extraSections: [
+      {
+        title: "Format & length",
+        guidance: "Format, target length, and any structural requirement.",
+      },
+      {
+        title: "Distribution & SEO",
+        guidance:
+          "Where it will be published and promoted, and target keywords if it is search-driven.",
+      },
+      {
+        title: "Subject-matter experts & review path",
+        guidance:
+          "Who provides the substance, who reviews for technical accuracy, and who approves.",
+      },
+    ],
+    placeholder:
+      "Example: Technical blog post on cutting build times, co-written with an engineer from the platform team. Should include real numbers from our own migration.",
+  },
+]
+
+export function getRequestType(id: string): RequestType | undefined {
+  return REQUEST_TYPES.find((t) => t.id === id)
+}
+
+/** The full ordered section list for a request type. */
+export function sectionsFor(typeId: string): Section[] {
+  const type = getRequestType(typeId)
+  if (!type) return []
+  return [...TEMPLATE_FAMILIES[type.family].sections, ...type.extraSections]
+}
+
+// --- Destinations -----------------------------------------------------------
+
+export interface Destination {
+  id: string
+  label: string
+  /** How the draft should shift for this reader. */
+  guidance: string
+}
+
+export const PRD_DESTINATIONS: Destination[] = [
+  {
+    id: "agent",
+    label: "AI coding agent (Claude Code, v0, Cursor)",
+    guidance:
+      "The reader is a coding agent that will build directly from this document, with no chance to ask a follow-up question. Optimize for buildability over readability: maximize acceptance criteria, the data model, explicit UI states, and edge cases. Minimize narrative prose, background, and anything about stakeholders or process. Be decisive and unambiguous — where a detail is genuinely undecided, state a specific recommended default and mark it as a decision the human should confirm, rather than leaving it open. Prefer tables and lists over paragraphs. Name concrete field types, routes, and states.",
+  },
+  {
+    id: "engineering",
+    label: "Engineering team",
+    guidance:
+      "The reader is an engineer who can ask questions but would rather not. Emphasize requirements, acceptance criteria, data, integrations, and non-functional constraints. Keep marketing framing brief.",
+  },
+  {
+    id: "design",
+    label: "Design",
+    guidance:
+      "The reader is a designer. Emphasize the user, the jobs to be done, flows, states, and content hierarchy. Describe outcomes and constraints rather than prescribing visual solutions.",
+  },
+  {
+    id: "content",
+    label: "Content & copy",
+    guidance:
+      "The reader is a writer. Emphasize audience, key message, proof points, tone, calls to action, and word-count or format constraints.",
+  },
+  {
+    id: "ops",
+    label: "Marketing Ops / lifecycle",
+    guidance:
+      "The reader runs the systems. Emphasize segmentation, suppression, data fields, tracking and UTM conventions, timing, and compliance. Be precise about anything that touches the CRM or ESP.",
+  },
+  {
+    id: "leadership",
+    label: "Cross-functional / leadership",
+    guidance:
+      "The reader is deciding whether to fund this. Lead with objective, success metrics, scope, and cost. Keep implementation detail short. Make the decision being asked for explicit.",
+  },
+]
+
+export function getDestination(id: string): Destination | undefined {
+  return PRD_DESTINATIONS.find((d) => d.id === id)
+}
+
+// --- Markdown constraints ---------------------------------------------------
+
+/**
+ * Notion turns pasted markdown into native blocks, but only for the subset it
+ * parses. Staying inside this subset is what makes "Copy for Notion" land as
+ * real headings and lists rather than literal ## and **.
+ */
+export const MARKDOWN_RULES = `
+OUTPUT FORMAT — this document gets pasted directly into Notion, so stay inside the markdown Notion parses:
+
+USE:
+- "# Title" once at the top, then "## " for each section and "### " for sub-headings
+- "- " for bullets, "1. " for numbered lists
+- "**bold**" for emphasis and for inline labels
+- Pipe tables with a header separator row, for data models and structured lists
+- Fenced code blocks with a language tag, for schemas or examples
+
+DO NOT USE:
+- Raw HTML of any kind
+- Horizontal rules ("---" or "***")
+- Footnotes, definition lists, or task-list checkboxes
+- List nesting deeper than two levels
+- Emoji
+- A leading or trailing code fence around the whole document — output the markdown itself, not a fenced block containing it
+
+Start immediately with the "# " title line. No preamble, no "Here is the PRD", no commentary after the final section.
+`
+
+// --- Intake -----------------------------------------------------------------
+
+export interface PrdIntake {
+  requestType: string
+  destination: string
+  title: string
+  brainDump: string
+  audience?: string
+  outcome?: string
+  targetDate?: string
+  requestingTeam?: string
+  constraints?: string
+  links?: string
+}
+
+export interface ClarifyingAnswer {
+  question: string
+  answer: string
+}
+
+/** Renders intake into the labelled block both prompts read from. */
+export function formatIntake(
+  intake: PrdIntake,
+  answers: ClarifyingAnswer[] = []
+): string {
+  const type = getRequestType(intake.requestType)
+  const destination = getDestination(intake.destination)
+
+  const rows: [string, string | undefined][] = [
+    ["Request type", type?.label ?? intake.requestType],
+    ["Document is for", destination?.label ?? intake.destination],
+    ["Working title", intake.title],
+    ["Audience / users", intake.audience],
+    ["Desired outcome", intake.outcome],
+    ["Target date", intake.targetDate],
+    ["Requesting team", intake.requestingTeam],
+    ["Known constraints", intake.constraints],
+    ["Reference links", intake.links],
+  ]
+
+  const fields = rows
+    .filter(([, value]) => value && value.trim().length > 0)
+    .map(([label, value]) => `${label}: ${value!.trim()}`)
+    .join("\n")
+
+  const answered = answers
+    .filter((a) => a.answer.trim().length > 0)
+    .map((a) => `Q: ${a.question}\nA: ${a.answer.trim()}`)
+    .join("\n\n")
+
+  return [
+    fields,
+    `\nWhat the requester wrote:\n${intake.brainDump.trim()}`,
+    answered ? `\nClarifying answers from the requester:\n${answered}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n")
+}
+
+// --- Prompts ----------------------------------------------------------------
+
+export function buildTriageSystemPrompt(): string {
+  return `You screen incoming work requests before a PRD is drafted from them.
+
+Your job is to decide one thing: is there enough real, specific context here to write a PRD that would actually be useful, or would drafting now produce confident-sounding filler?
+
+Mark the request READY when you can infer, from what the requester wrote, all of:
+- what they want built or produced
+- who it is for
+- why it matters, or what outcome it should drive
+
+Mark it NOT READY only when a genuine gap would force you to invent something load-bearing. In that case return one to three questions — never more.
+
+Rules for the questions:
+- Ask only about gaps that would materially change the document. Do not ask for detail that belongs in the PRD's own open-questions section.
+- Ask about substance, not formatting or preferences.
+- Make each question answerable in a sentence or two. No compound questions.
+- Be specific. "Who are the two or three user roles, and what can each of them do?" beats "Can you tell me more about the users?"
+- Never ask something the requester already answered in the fields or their description.
+
+Bias toward READY. A requester who wrote several specific sentences should not be interrogated. Questions are for requests that are genuinely too thin to draft from.
+
+For each question, also give a short reason explaining what you would otherwise have to guess.`
+}
+
+export type DraftMode = "draft" | "refine"
+
+export function buildDraftSystemPrompt(
+  typeId: string,
+  destinationId: string,
+  mode: DraftMode
+): string {
+  const type = getRequestType(typeId)
+  const destination = getDestination(destinationId)
+  const sections = sectionsFor(typeId)
+
+  const sectionSpec = sections
+    .map((s, i) => `${i + 1}. ## ${s.title}\n   ${s.guidance}`)
+    .join("\n")
+
+  const shared = `You write product requirements documents from rough requests. The requester is a marketer or an internal stakeholder, not a product manager — they describe what they want in a few sentences and you turn it into a document their team can execute against.
+
+${VERCEL_WRITING_RULES_BRIEF}
+
+REQUEST TYPE: ${type?.label ?? typeId}
+${type?.guidance ?? ""}
+
+WHO THIS DOCUMENT IS FOR: ${destination?.label ?? destinationId}
+${destination?.guidance ?? ""}
+
+REQUIRED SECTIONS — every one of these, in this order, using the exact "## " heading text given:
+
+${sectionSpec}
+
+HARD RULES:
+1. Never leave a section empty and never write "N/A" or "To be determined" as a whole section. If the requester gave you nothing for a section, write what you can infer, label the inference as an assumption, and put the specific unknown in the open-questions section as a question addressed to a role.
+2. Never invent a metric, target, budget, headcount, or date. If a number was not provided, write "TBD — needs input from <role>". A fabricated number inside an authoritative document is worse than an admitted gap.
+3. Do not output an empty skeleton. Every section gets real content — inferred and labelled where necessary, but never a placeholder.
+4. Distinguish what the requester said from what you inferred. Mark inferences with "**Assumption:**" so a reviewer can check them.
+5. Populate the out-of-scope list even when the requester mentioned no limits. Name the obvious adjacent asks this does NOT include. This is the section that saves the most time later.
+6. Be concrete. Prefer a named role over "the team", a specific field name over "user data", a stated behavior over "handle appropriately".
+
+${MARKDOWN_RULES}`
+
+  if (mode === "refine") {
+    return `${shared}
+
+YOU ARE REVISING AN EXISTING DOCUMENT.
+
+You will receive the current PRD and a revision instruction. Apply the instruction and return the complete revised document.
+
+- Change only what the instruction asks for. Leave every other section byte-for-byte as it was.
+- Keep all section headings and their order intact.
+- If the instruction asks for something that would require a fact you do not have, make the structural change and add the missing fact to the open-questions section rather than inventing it.
+- If the instruction is ambiguous, apply the most conservative reading and note what you took it to mean in the open-questions section.
+- Return the full document, not a diff and not a summary of your changes.`
+  }
+
+  return shared
+}

--- a/src/lib/vercel-style-guide.ts
+++ b/src/lib/vercel-style-guide.ts
@@ -1,0 +1,124 @@
+/**
+ * Vercel brand voice, in two sizes.
+ *
+ * VERCEL_STYLE_GUIDE is the full guide for tools that produce customer-facing
+ * copy. VERCEL_WRITING_RULES_BRIEF is the condensed version for internal
+ * documents, where the full copywriting guide would push the output into a
+ * marketing register it shouldn't be in.
+ */
+
+export const VERCEL_STYLE_GUIDE = `
+VERCEL STYLE GUIDE PRINCIPLES:
+
+1. KEEP SENTENCES SHORT
+- Write short, declarative sentences
+- Every time you use a comma, consider using a period instead
+- Remove unnecessary "filler" words
+- A great sentence is a good sentence made shorter
+
+2. VARY SENTENCE LENGTH
+- Use short sentences for impact
+- Use longer sentences to build momentum
+- Mix phrasing to avoid sounding robotic
+
+3. WRITE LIKE YOU SPEAK
+- Avoid corporate jargon and marketing fluff
+- Use simple, shorter words (facilitate → help, utilize → use, commence → start)
+- Don't get fancy. Get to the point faster.
+- Sentences can start with "but" and "and" (but don't overdo it)
+
+4. BE SPECIFIC AND BENEFIT-DRIVEN
+- Back statements with facts or data
+- Use "best", "bigger", "better", "faster" only with context (e.g., "6× faster deploys")
+- Lead with the benefit, not the feature
+- Be precise. Avoid vague claims.
+- Examples from Vercel:
+  * "One endpoint, all your models" (not "Unified AI gateway")
+  * "Helping teams ship 6× faster" (not "Faster deployments")
+  * "Fast, scalable, and reliable" (three concrete benefits)
+
+5. BE CONFIDENT BUT CLIPPED
+- Avoid phrases like "I think," "maybe," "could" that soften impact
+- Be bold, but also humble
+- Know the difference between confidence and arrogance
+- Keep tone professional and matter-of-fact
+
+6. HIGHLIGHT CUSTOMERS & COMMUNITY
+- Feature customer thoughts and words
+- Use customer quotes to show value versus telling
+- Let customers do the talking
+
+7. SAY "YOU" MORE THAN "WE"
+- Make it about the reader, not us
+- Less "we did" and more "you can"
+- Empathize with their challenges
+
+8. USE ACTIVE VOICE
+- Active voice is more interesting and direct
+- Avoid passive constructions with "has", "was", "by", or words ending in "-ed"
+- Test: If adding "...by monkeys" makes sense, you're using passive voice
+
+9. USE POSITIVE PHRASING
+- Say what something IS rather than what it ISN'T
+- Positive tone is uplifting and enabling
+- Swap confrontational conjunctions for positive ones
+
+10. NEVER USE EXCLAMATION POINTS
+- Vercel does not use exclamation points in company messaging
+- Ever. Period. No exceptions.
+- Keep tone calm, confident, and factual
+- Let the substance of your message create impact, not punctuation
+- Replace excitement with clear, concrete benefits
+
+11. MAKE IT SCANNABLE
+- Use bullet points and lists liberally
+- Break long paragraphs into shorter ones
+- Lead with the most important information
+- Use clear hierarchies (headers, subheaders)
+- One idea per paragraph
+
+12. ACTION-ORIENTED LANGUAGE
+- Start with strong verbs: Build, Deploy, Scale, Protect, Monitor
+- Examples from Vercel docs:
+  * "Deploy at the speed of AI" (not "AI-powered deployments")
+  * "Automate away repetition" (not "Automation tools")
+  * "Extend and automate workflows" (not "Workflow extensions")
+- Make the reader the hero doing the action
+
+13. TECHNICAL PRECISION WITHOUT JARGON
+- Use technical terms when they're the clearest option
+- Define or contextualize complex concepts immediately
+- Avoid buzzwords and marketing speak
+- Examples from Vercel:
+  * "Fluid compute, active CPU, and provisioned memory" (specific, not "powerful infrastructure")
+  * "Incremental Static Regeneration" (precise term, then explain what it does)
+
+14. STRIP QUALIFIERS AND HEDGING
+- Remove: "basically", "essentially", "probably", "might", "should"
+- Vercel states facts directly
+- Wrong: "This will basically help you deploy faster"
+- Right: "Deploy 6× faster"
+
+15. COLON CLARITY
+- Vercel uses colons to connect concepts clearly
+- Format: "Thing: What it does"
+- Examples:
+  * "Bot Management: Scalable bot protection"
+  * "Functions: API routes with Fluid compute"
+  * "Draft Mode: View your unpublished CMS content"
+`
+
+/**
+ * The internal-document register. Same voice, none of the copywriting pressure —
+ * a PRD should read like a clear brief, not like a landing page.
+ */
+export const VERCEL_WRITING_RULES_BRIEF = `
+WRITING STYLE:
+- Short, declarative sentences. Prefer a period over a comma.
+- Active voice. "The requester picks a date", not "a date will be picked".
+- Say "you" more than "we". Plain words over jargon (use, not utilize).
+- Be specific. Name the number, the system, the person, the date. Never write a vague claim.
+- Strip hedging: no "basically", "essentially", "probably", "might", "should".
+- Never use exclamation points.
+- Make it scannable: bullets over paragraphs, one idea per line, most important thing first.
+`


### PR DESCRIPTION
Turns a rough request into a structured PRD, generated through AI Gateway. Paste the result straight into Notion.

## Why

Requests arrive under-specified — campaigns, pages, emails, and increasingly apps and tools. Whoever picks it up spends a round trip or three extracting the objective, the users, the metric, and what's explicitly *out* of scope. This does that extraction up front.

## How it works

**Two template families, one engine.** Marketing requests (campaign, launch/GTM, email, page, event, content) and app/product requests (new app, feature, integration). A request type picks a family and adds its own sections, so adding a type is a config entry in `src/lib/prd-template.ts` rather than new code.

**"Who is this for" tunes emphasis** without changing the section list. The **AI coding agent** setting is the one with teeth: it pushes toward buildability — user stories with Given/When/Then, a data model with field types, explicit empty/loading/error states — and asks for a stated recommended default on undecided points rather than an open question, because an agent can't come back and ask.

**Two calls.** A cheap Haiku triage pass decides whether there's enough context to draft from, returning up to three targeted questions if not — always with a "skip and draft anyway" escape hatch. The draft then streams as markdown so sections appear as they're written instead of ~40s of spinner.

**Three guardrails in the draft prompt:**
1. Never leave a section blank — unknowns become open questions addressed to a role
2. Never invent a metric, budget, or date — write `TBD — needs input from <role>`. A fabricated number inside an authoritative-looking document is worse than an admitted gap.
3. Stay inside the markdown subset Notion parses into blocks, so **Copy for Notion** lands as real headings, lists and tables rather than literal `##` and `**`

**Stateless.** This app has no auth, so nothing is persisted server-side — saved PRDs would be readable by anyone with the URL. Intake and the latest draft mirror to `localStorage`, and a client-side refine loop with undo covers revisions.

## Models

| Call | Model |
|---|---|
| Triage | `anthropic/claude-haiku-4-5` |
| Draft | `anthropic/claude-opus-5` |
| Draft fallback | `anthropic/claude-sonnet-4-6` |

`streamText` resolves before the model is reached, so a try/catch around it catches nothing — a rejected model id only surfaces once the stream is consumed, when the response is already committed. `src/app/api/prd/draft/route.ts` pulls the first chunk while a retry is still possible, then replays it into the response body. Whichever model served is returned in an `X-Prd-Model` header and shown in the UI, so it's visible whether Opus 5 is live on the gateway or the fallback is carrying it.

## Verification status

Verified: `tsc --noEmit` clean, eslint clean, `next build` succeeds with all three routes registered, page renders, and both API routes exercised via curl — every validation path returns the right 400 and valid payloads reach the `AI_GATEWAY_API_KEY` guard.

**Not yet verified — needs a preview deploy with the gateway key.** `AI_GATEWAY_API_KEY` isn't in local `.env.local` (the existing AI tools fail locally for the same reason), so the model calls themselves are untested. Please check on the preview URL:

- [ ] **Meeting booking app**: type *New app or tool*, destination *AI coding agent*. Could an agent build v1 from the output without coming back? Check the user stories carry real Given/When/Then, the data model names entities and fields, and screens cover empty/loading/error
- [ ] Thin input (e.g. "we need a landing page for the AI event") returns **questions**, not a draft
- [ ] Input with no metric mentioned → success metrics says `TBD`, **not** an invented number
- [ ] **Copy for Notion** → paste into a real Notion doc, confirm native blocks
- [ ] Refine + Undo behave
- [ ] Dark mode and mobile width
- [ ] Check which model the `X-Prd-Model` badge reports

## Note

Branched off current `main` (`6b3e3a8`), not off `feat/calendar-location-param` where the work was written — that branch's change is already on main via #49, so basing here avoids re-proposing it.

Also unrelated but worth a separate fix: `npm run lint` is broken repo-wide since `next lint` was removed in Next 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)