### PR TITLE
feat(email-catalogue): clickable links, hover click counts, glow heatmap

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -281,3 +281,75 @@
   border-style: solid;
   border-width: 1px;
 }
+
+/* Glow blobs — the clickmap look. Purely decorative: they never take pointer
+   events, so the hit area beneath them owns hover and clicks. */
+.heat-glow {
+  position: absolute;
+  border-radius: 50%;
+  pointer-events: none;
+  filter: blur(11px);
+  will-change: transform;
+}
+
+/* Transparent hit area sitting exactly on the link. Owns hover (for the
+   tooltip) and the click that opens the destination. Present even when the
+   heatmap is hidden, so links stay clickable either way. */
+.heat-hit {
+  position: absolute;
+  display: block;
+  border-radius: 3px;
+  pointer-events: auto;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.heat-hit:focus-visible {
+  outline: 2px solid hsl(var(--foreground));
+  outline-offset: 2px;
+}
+
+/* Links whose clicks can't be attributed keep a visible marker, since a glow
+   would imply a number we don't have. */
+.heat-layer[data-heatmap="on"] .heat-hit[data-flag="unattributable"] {
+  outline: 2px dashed #fab219;
+  outline-offset: 1px;
+  background: rgba(250, 178, 25, 0.12);
+}
+
+.heat-hit[data-flag="not-navigable"] {
+  cursor: default;
+}
+
+/* Hover tooltip. */
+.heat-tip {
+  position: absolute;
+  z-index: 10;
+  max-width: 320px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: hsl(var(--popover));
+  color: hsl(var(--popover-foreground));
+  border: 1px solid hsl(var(--border));
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+  font-size: 12px;
+  line-height: 1.45;
+  pointer-events: none;
+}
+
+.heat-tip-count {
+  font-size: 15px;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+}
+
+.heat-tip-href {
+  margin-top: 3px;
+  color: hsl(var(--muted-foreground));
+  word-break: break-all;
+}
+
+.heat-tip-note {
+  margin-top: 4px;
+  color: hsl(var(--muted-foreground));
+}

--- a/src/components/email-catalogue/EmailFrame.tsx
+++ b/src/components/email-catalogue/EmailFrame.tsx
@@ -4,7 +4,8 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { matchAnchors, type AnchorMatch, type MatchReport } from "@/lib/catalogue/match"
 import {
   DARK_GROUND_THRESHOLD,
-  heatStyle,
+  glowDiameter,
+  glowGradient,
   luminanceOf,
   type HeatState,
 } from "@/lib/catalogue/heat"
@@ -36,6 +37,10 @@ export interface HeatSpot {
   isPrimaryRect: boolean
   /** Ground behind this link is dark, so the ramp anchor flips. */
   onDark: boolean
+  /** Share of the busiest link's clicks, 0–1. Drives glow size and colour. */
+  share: number
+  /** Absolute http(s) destination, or null when it isn't navigable. */
+  destination: string | null
 }
 
 interface Props {
@@ -69,6 +74,7 @@ function groundIsDark(el: Element, win: Window): boolean {
 export function EmailFrame({ html, links, basis, showHeatmap, highlightLiquid, onReport }: Props) {
   const frameRef = useRef<HTMLIFrameElement>(null)
   const [spots, setSpots] = useState<HeatSpot[]>([])
+  const [hovered, setHovered] = useState<number | null>(null)
   const [height, setHeight] = useState(600)
 
   // Ranks and the busiest link are per-email, so a hot link in a small send
@@ -150,6 +156,11 @@ export function EmailFrame({ html, links, basis, showHeatmap, highlightLiquid, o
                 : "cold"
 
       const onDark = groundIsDark(anchor, win)
+      const share = maxClicks > 0 ? Math.min(1, clicks / maxClicks) : 0
+      // Navigate to the resolved destination — the cio_link tag's url when
+      // present, otherwise the href as authored. Liquid and non-web schemes have
+      // no fixed target, so those aren't navigable.
+      const destination = toNavigable(match.resolvedHref)
 
       rects.forEach((rect, rectIndex) => {
         next.push({
@@ -165,11 +176,16 @@ export function EmailFrame({ html, links, basis, showHeatmap, highlightLiquid, o
           state,
           isPrimaryRect: rectIndex === 0,
           onDark,
+          share,
+          destination,
         })
       })
     })
 
     setSpots(next)
+    // Indices change when the document reflows; a stale one would pin a tooltip
+    // to the wrong link.
+    setHovered(null)
     onReport?.({ ...report, hiddenSpots })
     // rankByIndex/clickValues are derived from links+basis, which are the real inputs.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -290,6 +306,8 @@ export function EmailFrame({ html, links, basis, showHeatmap, highlightLiquid, o
     }
   }, [measure, html])
 
+  const activeSpot = hovered != null ? spots[hovered] : null
+
   return (
     <div className="relative" style={{ background: "#ffffff" }}>
       <iframe
@@ -304,37 +322,154 @@ export function EmailFrame({ html, links, basis, showHeatmap, highlightLiquid, o
         style={{ width: "100%", height, border: "none", display: "block" }}
       />
 
-      {showHeatmap && (
-        <div className="heat-layer" aria-hidden={false}>
-          {spots.map((spot, i) => {
-            const style = heatStyle(spot.clicks, maxClicks, spot.state, spot.onDark)
-            return (
+      {/*
+        The overlay is always mounted, even with the heatmap hidden, because it
+        owns link clicks and hover tooltips. Hiding it would silently make the
+        email's links dead.
+      */}
+      <div className="heat-layer" data-heatmap={showHeatmap ? "on" : "off"}>
+        {showHeatmap &&
+          spots.map((spot, i) =>
+            spot.state === "hot" ? (
               <div
-                key={i}
-                className="heat-spot"
-                data-state={style.state}
-                tabIndex={0}
-                aria-label={describeSpot(spot, maxClicks)}
-                title={describeSpot(spot, maxClicks)}
-                style={{
-                  top: spot.rect.top,
-                  left: spot.rect.left,
-                  width: spot.rect.width,
-                  height: spot.rect.height,
-                  background: style.fill,
-                  borderColor: style.stroke,
-                }}
-              >
-                {spot.rank != null && spot.isPrimaryRect && (
-                  <span className="heat-rank">{spot.rank}</span>
-                )}
-              </div>
-            )
-          })}
-        </div>
-      )}
+                key={`glow-${i}`}
+                className="heat-glow"
+                style={glowBoxStyle(spot)}
+                aria-hidden
+              />
+            ) : null,
+          )}
+
+        {spots.map((spot, i) => {
+          const flag =
+            spot.state === "templated" || spot.state === "unattributed"
+              ? "unattributable"
+              : spot.destination
+                ? undefined
+                : "not-navigable"
+          const label = describeSpot(spot, maxClicks)
+          const shared = {
+            className: "heat-hit",
+            "data-flag": flag,
+            "data-state": spot.state,
+            style: {
+              top: spot.rect.top,
+              left: spot.rect.left,
+              width: spot.rect.width,
+              height: spot.rect.height,
+            },
+            onMouseEnter: () => setHovered(i),
+            onMouseLeave: () => setHovered((prev) => (prev === i ? null : prev)),
+            onFocus: () => setHovered(i),
+            onBlur: () => setHovered((prev) => (prev === i ? null : prev)),
+            "aria-label": label,
+          } as const
+
+          // rel=noopener noreferrer: these are third-party destinations from
+          // email content, so the new tab gets no handle on this page.
+          return spot.destination ? (
+            <a
+              key={`hit-${i}`}
+              {...shared}
+              href={spot.destination}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {spot.rank != null && spot.isPrimaryRect && showHeatmap && (
+                <span className="heat-rank">{spot.rank}</span>
+              )}
+            </a>
+          ) : (
+            <div key={`hit-${i}`} {...shared} tabIndex={0} role="note">
+              {spot.rank != null && spot.isPrimaryRect && showHeatmap && (
+                <span className="heat-rank">{spot.rank}</span>
+              )}
+            </div>
+          )
+        })}
+
+        {activeSpot && <Tooltip spot={activeSpot} maxClicks={maxClicks} />}
+      </div>
     </div>
   )
+}
+
+/** Centre the glow on the link's box and size it by intensity. */
+function glowBoxStyle(spot: HeatSpot): React.CSSProperties {
+  const diameter = glowDiameter(spot.rect.width, spot.rect.height, spot.share)
+  return {
+    top: spot.rect.top + spot.rect.height / 2 - diameter / 2,
+    left: spot.rect.left + spot.rect.width / 2 - diameter / 2,
+    width: diameter,
+    height: diameter,
+    background: glowGradient(spot.share),
+  }
+}
+
+/**
+ * Hover tooltip. Leads with the number, because that's what the glow can only
+ * approximate.
+ */
+function Tooltip({ spot, maxClicks }: { spot: HeatSpot; maxClicks: number }) {
+  const share = maxClicks > 0 ? Math.round((spot.clicks / maxClicks) * 100) : 0
+  const attributable = spot.state === "hot" || spot.state === "cold"
+
+  // Above the link when there's room, below when it would clip off the top.
+  const above = spot.rect.top > 78
+  const style: React.CSSProperties = {
+    left: Math.max(6, spot.rect.left),
+    top: above ? spot.rect.top - 10 : spot.rect.top + spot.rect.height + 10,
+    transform: above ? "translateY(-100%)" : undefined,
+  }
+
+  return (
+    <div className="heat-tip" style={style} role="tooltip">
+      {attributable ? (
+        <>
+          <div className="heat-tip-count">
+            {spot.clicks.toLocaleString()} {spot.clicks === 1 ? "click" : "clicks"}
+          </div>
+          <div>
+            {spot.rank != null ? `#${spot.rank} in this email · ` : ""}
+            {share}% of the busiest link
+          </div>
+        </>
+      ) : (
+        <div className="heat-tip-count">No click data</div>
+      )}
+      <div className="heat-tip-href">{spot.destination ?? spot.match.href}</div>
+      {!attributable && <div className="heat-tip-note">{reasonFor(spot)}</div>}
+      {spot.destination && <div className="heat-tip-note">Click to open in a new tab</div>}
+    </div>
+  )
+}
+
+function reasonFor(spot: HeatSpot): string {
+  switch (spot.state) {
+    case "templated":
+      return "Built with Liquid, so its destination was only decided at send time."
+    case "tracking-off":
+      return "Link tracking is switched off for this link."
+    case "untrackable":
+      return "Not a trackable web link."
+    default:
+      return "Customer.io has no click data for this link."
+  }
+}
+
+/** An absolute http(s) URL, or null when the value can't be opened. */
+function toNavigable(href: string): string | null {
+  if (!href || hasLiquidish(href)) return null
+  try {
+    const url = new URL(href)
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : null
+  } catch {
+    return null
+  }
+}
+
+function hasLiquidish(href: string): boolean {
+  return /\{\{|\{%/.test(href)
 }
 
 /** Hover/screen-reader text. Says plainly when a number isn't knowable. */

--- a/src/components/email-catalogue/HeatLegend.tsx
+++ b/src/components/email-catalogue/HeatLegend.tsx
@@ -1,16 +1,17 @@
 "use client"
 
-import { legendStops, UNATTRIBUTED_COLOR } from "@/lib/catalogue/heat"
+import { glowLegendStops, UNATTRIBUTED_COLOR } from "@/lib/catalogue/heat"
 
 /**
- * The sequential ramp legend, plus the three non-magnitude states.
+ * Legend for the glow heatmap.
  *
- * The special states are spelled out rather than left to be inferred: a link with
- * no tint could otherwise mean "nobody clicked", "we couldn't match it", or "its
- * destination was Liquid", and those are very different claims.
+ * Two things need saying that the glow alone can't: that no glow means no clicks
+ * (rather than an unmeasured link), and that a dashed marker means the clicks
+ * exist but can't be attributed. Both are claims a reader would otherwise have to
+ * guess at.
  */
 export function HeatLegend({ maxClicks }: { maxClicks: number }) {
-  const gradient = `linear-gradient(to right, ${legendStops().join(", ")})`
+  const gradient = `linear-gradient(to right, ${glowLegendStops().join(", ")})`
 
   return (
     <div className="flex flex-wrap items-center gap-x-6 gap-y-3 text-xs text-muted-foreground">
@@ -23,20 +24,19 @@ export function HeatLegend({ maxClicks }: { maxClicks: number }) {
       </div>
 
       {/*
-        Border token, not the spot's own stroke: the legend sits on toolkit
-        chrome, which follows the site theme, while a real spot sits on the
-        email's own background. A hardcoded dark stroke would vanish in dark mode.
+        Glow intensity is the only positive signal now, so the absence of one has
+        to be stated. Customer.io reports only links that were clicked, so no glow
+        means no clicks — not a missing measurement.
       */}
-      <Swatch label="No clicks" className="border-dotted border-border" />
-      <Swatch label="Not trackable (mailto, tel, anchor)" className="border-solid border-border" />
+      <span>No glow = no clicks</span>
 
       {/*
-        Liquid, no-match, and ambiguous share one treatment because they share one
-        meaning: a number we decline to claim. Listing them separately with
-        identical swatches only implied a distinction the colors don't make.
+        The one state that still needs a drawn marker: a link whose clicks can't
+        be attributed. A glow would imply a number we don't have, and leaving it
+        bare would read as "no clicks", which is a different claim.
       */}
       <Swatch
-        label="Not attributable — Liquid or ambiguous"
+        label="Not attributable"
         icon="⚠"
         className="border-dashed"
         style={{ background: "rgba(250, 178, 25, 0.18)", borderColor: UNATTRIBUTED_COLOR }}
@@ -48,6 +48,7 @@ export function HeatLegend({ maxClicks }: { maxClicks: number }) {
         </span>
         Rank by clicks
       </span>
+      <span>Hover a link for its exact count · click to open it</span>
     </div>
   )
 }

--- a/src/lib/catalogue/heat.ts
+++ b/src/lib/catalogue/heat.ts
@@ -173,3 +173,82 @@ export function hexToRgba(hex: string, alpha: number): string {
   const b = parseInt(clean.slice(4, 6), 16)
   return `rgba(${r}, ${g}, ${b}, ${alpha})`
 }
+
+
+// =============================================================================
+// Glow rendering — the classic clickmap look
+// =============================================================================
+
+/**
+ * Cool→hot ramp for the radial glow, in the idiom people expect from a
+ * clickmap: a violet/blue halo for light traffic, building through green and
+ * yellow to a red core on the busiest links.
+ *
+ * This is deliberately a rainbow, which the sequential-colour rule elsewhere in
+ * this file avoids — a multi-hue ramp isn't perceptually uniform and isn't
+ * colourblind-safe, so it can imply boundaries the data doesn't have. It's used
+ * here because a clickmap's job is "where did attention go", answered at a
+ * glance across a whole email, and this is the convention readers already know.
+ *
+ * The precision lives in channels that don't depend on hue: every link carries a
+ * rank badge, a hover tooltip with the exact count, and a row in the link table.
+ */
+const GLOW_RAMP = [
+  "#5b30d6", // violet — faintest
+  "#2f6fe0", // blue
+  "#1fa8c8", // cyan
+  "#2ecc71", // green
+  "#a3e635", // lime
+  "#facc15", // yellow
+  "#f97316", // orange
+  "#ef4444", // red — hottest
+] as const
+
+function rampAt(index: number): string {
+  return GLOW_RAMP[Math.max(0, Math.min(GLOW_RAMP.length - 1, index))]
+}
+
+/**
+ * Build the radial gradient for one link's glow.
+ *
+ * The core colour is the ramp position for this link's share; cooler stops fan
+ * outward to transparent. So a weak link is a soft blue smudge and a dominant
+ * one has a red centre ringed by yellow, green and blue — the intensity reads
+ * from the core, not from the blob's presence.
+ */
+export function glowGradient(share: number): string {
+  const top = Math.round(Math.min(1, Math.max(0, share)) * (GLOW_RAMP.length - 1))
+  const stops: string[] = []
+
+  // Centre outward: ramp[top] → ramp[top-1] → … → ramp[0] → transparent.
+  const rings = top + 1
+  for (let i = 0; i <= top; i++) {
+    const colour = rampAt(top - i)
+    const position = (i / rings) * 72
+    // Opaque at the core, fading with radius so email content stays legible.
+    const alpha = 0.62 * (1 - i / (rings + 0.6))
+    stops.push(`${hexToRgba(colour, Math.max(0.12, alpha))} ${position.toFixed(1)}%`)
+  }
+  stops.push(`${hexToRgba(rampAt(0), 0)} 100%`)
+
+  return `radial-gradient(circle, ${stops.join(", ")})`
+}
+
+/**
+ * Blob diameter for a link's box.
+ *
+ * Deliberately only weakly tied to the element's size. A real heatmap draws a
+ * fixed-radius kernel per click, so the blob represents click position, not the
+ * clickable area — scaling it to the element meant a large hero image produced a
+ * ~700px blob that swallowed the whole email. Clamped at both ends so a tiny
+ * text link still reads and a big image stays a marker rather than a wash.
+ */
+export function glowDiameter(width: number, height: number, share: number): number {
+  const base = Math.max(width, height)
+  return Math.min(240, Math.max(88, base * 0.5 + 64 + share * 30))
+}
+
+/** Ramp stops for the glow legend, coolest first. */
+export function glowLegendStops(): string[] {
+  return [...GLOW_RAMP]
+}


### PR DESCRIPTION
Follow-up to #53, which shipped the catalogue itself. Three changes to how the overlay behaves, all against the real Customer.io archive.

## Links now open

The overlay sat on top of the email and swallowed every click, so no link in any catalogued email was clickable. Each link's hit area is now an anchor to its real destination, opening in a new tab with `rel="noopener noreferrer"` — these are third-party URLs pulled from email content, so the new tab gets no handle on this page.

It navigates to the **resolved** destination, so a `{% cio_link url:… %}` tag opens its `url:` rather than the tag text. Liquid-built and non-web hrefs have no fixed target and stay deliberately non-navigable rather than opening something invented.

Consequence worth noting in review: **the overlay is now always mounted**, even with the heatmap toggled off, because it owns link clicks. Unmounting it would silently make every link dead.

## Hover shows the exact count

Tooltip on hover/focus with the click count, rank within the email, share of the busiest link, and the destination. The glow can only approximate a number; this is where the number lives. Replaces the native `title` attribute, which was slow to appear and unstyleable.

## Heatmap redrawn as glows

Radial glows in the conventional clickmap idiom — a violet halo for light traffic building through green and yellow to a red core on the busiest link.

Two things reviewers should weigh:

- **This is a rainbow ramp**, which the sequential-colour rule the rest of `heat.ts` follows deliberately avoids: multi-hue ramps aren't perceptually uniform or colourblind-safe, and can imply boundaries the data doesn't have. It's used because a clickmap answers "where did attention go" at a glance and this is the convention readers already know. The precision is kept in channels that don't depend on hue — rank badges, the hover tooltip, and the link table. Easy to swap for a perceptually-uniform ramp if preferred.
- **Blob size is only weakly tied to element size.** The first attempt scaled it to the element, which made a hero image produce a ~700px blob that swallowed the whole email. A real heatmap draws a fixed-radius kernel per click, marking position rather than clickable area, so it's now clamped at both ends.

## Legend corrected

It advertised dotted and solid swatches for states that no longer draw anything. It now states the two things the glow can't convey: that no glow means **no clicks** (Customer.io reports only links that were clicked, so absence is a real zero, not an unmeasured link), and that a dashed marker means clicks exist but can't be attributed.

## Verification

- 49 unit tests, `tsc --noEmit`, and eslint all clean; `npm ci` from `main`'s lockfile then a full production build.
- Checked in headless Chrome against a real 989,874-send newsletter: 18 glows, 18 navigable links, all 18 with `rel="noopener noreferrer"`.
- Visually confirmed the ramp reads correctly — red core on the top link, teal mid-range, faint violet on the weakest.

**Not verified:** the tooltip's hover behaviour. `--dump-dom` can't simulate hover, so the markup and handlers are confirmed but its on-screen appearance is not. Worth a click-through on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
