### PR TITLE
fix(email-catalogue): exclude non-emails, A/B containers, and test sends

### DIFF
--- a/scripts/ingest.ts
+++ b/scripts/ingest.ts
@@ -219,14 +219,29 @@ function abContainerIds(actions: CioAction[]): Set<string> {
   return containers
 }
 
-/** Email steps only — journeys also contain SMS, push, and webhook actions. */
+/**
+ * Email steps only.
+ *
+ * A journey also contains webhook, attribute_update, create_event, SMS and push
+ * steps, and several of those carry a `body` — a JSON payload, not markup. This
+ * previously ended in a `|| Boolean(a.body)` catch-all, which admitted all of
+ * them: a webhook step surfaced in the catalogue as an "email" whose rendering
+ * was `{"email": "{{customer.email}}", "ip": "127.0.0.1"}`.
+ *
+ * This workspace has 161 email actions and 6 non-email actions carrying bodies
+ * (4 attribute_update, 1 create_event, 1 webhook), so the type is required to be
+ * exactly "email" rather than inferred from the presence of content. Every
+ * action Customer.io returned here has a type, so nothing legitimate is lost by
+ * being strict — and being loose means shipping webhook payloads as emails.
+ */
 function emailActions(actions: CioAction[]): CioAction[] {
   const containers = abContainerIds(actions)
-  return actions.filter(
-    (a) =>
-      !containers.has(String(a.id)) &&
-      (a.type === "email" || (!a.type && a.body) || Boolean(a.body)),
-  )
+  return actions.filter((a) => a.type === "email" && !containers.has(String(a.id)))
+}
+
+/** Non-email steps that carry a body, counted so the exclusion is visible. */
+function nonEmailWithBody(actions: CioAction[]): number {
+  return actions.filter((a) => a.type !== "email" && Boolean(a.body)).length
 }
 
 
@@ -234,7 +249,14 @@ interface Collected {
   entry: CatalogueEmail
 }
 
-const stats = { skippedUnsent: 0, withoutBody: 0, reusedBody: 0, skippedTest: 0, skippedAbContainers: 0 }
+const stats = {
+  skippedUnsent: 0,
+  withoutBody: 0,
+  reusedBody: 0,
+  skippedTest: 0,
+  skippedAbContainers: 0,
+  skippedNonEmail: 0,
+}
 
 /**
  * Decide whether an email counts as "sent".
@@ -331,6 +353,7 @@ async function collectCampaigns(prior: Map<string, CatalogueIndexEntry>): Promis
     const allActions = await listCampaignActions(c.id)
     const actions = emailActions(allActions)
     stats.skippedAbContainers += abContainerIds(allActions).size
+    stats.skippedNonEmail += nonEmailWithBody(allActions)
     const results: Collected[] = []
 
     for (const a of actions) {
@@ -577,6 +600,7 @@ async function main() {
       skippedUnsent: stats.skippedUnsent,
       skippedTest: stats.skippedTest,
       skippedAbContainers: stats.skippedAbContainers,
+      skippedNonEmail: stats.skippedNonEmail,
     },
     // Strip the heavy fields — the index page never needs HTML or link lists.
     emails: collected.map(({ entry }) => ({
@@ -605,6 +629,7 @@ async function main() {
   console.log(`  skipped (never sent): ${stats.skippedUnsent}`)
   console.log(`  skipped (test names): ${stats.skippedTest}`)
   console.log(`  skipped (A/B containers): ${stats.skippedAbContainers}`)
+  console.log(`  skipped (non-email steps with a body): ${stats.skippedNonEmail}`)
   if (stats.reusedBody) console.log(`  reused unchanged bodies: ${stats.reusedBody}`)
 }
 

--- a/scripts/ingest.ts
+++ b/scripts/ingest.ts
@@ -22,6 +22,7 @@
  *   npm run ingest -- --type newsletter     one surface only
  *   npm run ingest -- --force               re-fetch bodies even if unchanged
  *   npm run ingest -- --include-drafts      keep emails that never sent
+ *   npm run ingest -- --include-test        keep emails with test-ish names
  */
 
 import { config as loadEnv } from "dotenv"
@@ -87,6 +88,7 @@ const LIMIT = arg("limit") ? Number(arg("limit")) : Infinity
 const ONLY_TYPE = arg("type") as EmailSurface | undefined
 const FORCE = flag("force")
 const INCLUDE_DRAFTS = flag("include-drafts")
+const INCLUDE_TEST = flag("include-test")
 
 const DATA_DIR = path.join(process.cwd(), "data")
 
@@ -164,16 +166,75 @@ function toLinks(uniqueRes: CioLinkMetric[], rawRes: CioLinkMetric[]): Catalogue
   return mergeEquivalentLinks(Array.from(byHref.values()))
 }
 
+/**
+ * Names that mark an email as internal testing rather than a real send.
+ *
+ * Word-boundary matching, not a substring check. "test" appears inside ordinary
+ * marketing copy — this workspace has "Make the safe path the fastest path",
+ * and "latest", "greatest", "contest" and "testimonial" are all waiting to
+ * happen. A substring filter would silently hide real sends, which is worse than
+ * leaving a test email in.
+ *
+ * `test`, `tests`, `testing`, and `test2` match; `fastest` and `testimonial`
+ * don't.
+ */
+const TEST_NAME = /(?<![a-z])test(?:s|ing)?(?![a-z])/i
+
+/**
+ * Checked against the email's own name and its parent campaign's name, but
+ * deliberately NOT the subject line: a subject is customer-facing copy where
+ * "test" is legitimate ("A/B test your landing pages"), so matching it there
+ * would hide real campaigns.
+ */
+function isTestEmail(name: string | undefined, parentName: string | undefined): boolean {
+  if (INCLUDE_TEST) return false
+  return TEST_NAME.test(name ?? "") || TEST_NAME.test(parentName ?? "")
+}
+
+/**
+ * Identify the A/B containers in a campaign's actions.
+ *
+ * When a journey step has variants, Customer.io returns a parent action
+ * alongside its children: the parent carries no body, no sending_state, and
+ * metrics that are the SUM of its variants. Ingesting it produced a phantom
+ * bodiless email AND double-counted every send — campaign 43's parent reported
+ * 7,070 sends while its two variants reported 3,515 and 3,555.
+ *
+ * Note the id normalisation. Customer.io returns `id` as a STRING ("729") but
+ * `parent_action_id` as a NUMBER (729), so comparing them directly — or via a
+ * Set — silently never matches, which is exactly how the containers slipped
+ * through the first attempt at this filter.
+ */
+function abContainerIds(actions: CioAction[]): Set<string> {
+  const parents = new Set<string>()
+  for (const a of actions) {
+    if (a.parent_action_id != null) parents.add(String(a.parent_action_id))
+  }
+  // Only ids that actually appear as actions count as containers.
+  const present = new Set(actions.map((a) => String(a.id)))
+  const containers = new Set<string>()
+  parents.forEach((id) => {
+    if (present.has(id)) containers.add(id)
+  })
+  return containers
+}
+
 /** Email steps only — journeys also contain SMS, push, and webhook actions. */
 function emailActions(actions: CioAction[]): CioAction[] {
-  return actions.filter((a) => a.type === "email" || (!a.type && a.body) || Boolean(a.body))
+  const containers = abContainerIds(actions)
+  return actions.filter(
+    (a) =>
+      !containers.has(String(a.id)) &&
+      (a.type === "email" || (!a.type && a.body) || Boolean(a.body)),
+  )
 }
+
 
 interface Collected {
   entry: CatalogueEmail
 }
 
-const stats = { skippedUnsent: 0, withoutBody: 0, reusedBody: 0 }
+const stats = { skippedUnsent: 0, withoutBody: 0, reusedBody: 0, skippedTest: 0, skippedAbContainers: 0 }
 
 /**
  * Decide whether an email counts as "sent".
@@ -197,6 +258,10 @@ async function collectNewsletters(prior: Map<string, CatalogueIndexEntry>): Prom
   console.log(`newsletters: ${newsletters.length}`)
 
   const out = await mapPool(newsletters, 4, async (n) => {
+    if (isTestEmail(n.name, undefined)) {
+      stats.skippedTest++
+      return []
+    }
     const contents = await getNewsletterContents(n.id)
     const metrics = toMetrics(await getNewsletterMetrics(n.id))
     if (!wasSent(metrics)) {
@@ -263,10 +328,16 @@ async function collectCampaigns(prior: Map<string, CatalogueIndexEntry>): Promis
   console.log(`campaigns: ${campaigns.length}`)
 
   const out = await mapPool(campaigns, 3, async (c) => {
-    const actions = emailActions(await listCampaignActions(c.id))
+    const allActions = await listCampaignActions(c.id)
+    const actions = emailActions(allActions)
+    stats.skippedAbContainers += abContainerIds(allActions).size
     const results: Collected[] = []
 
     for (const a of actions) {
+      if (isTestEmail(a.name, c.name)) {
+        stats.skippedTest++
+        continue
+      }
       const metrics = toMetrics(await getCampaignActionMetrics(c.id, a.id))
       if (!wasSent(metrics)) {
         stats.skippedUnsent++
@@ -306,6 +377,10 @@ async function collectBroadcasts(prior: Map<string, CatalogueIndexEntry>): Promi
   console.log(`broadcasts: ${broadcasts.length}`)
 
   const out = await mapPool(broadcasts, 3, async (b) => {
+    if (isTestEmail(b.name, undefined)) {
+      stats.skippedTest++
+      return []
+    }
     const actions = emailActions(await listBroadcastActions(b.id))
     // Broadcast metrics are only available at the broadcast level, so a
     // multi-action broadcast shares one set of totals across its steps.
@@ -363,6 +438,10 @@ async function collectTransactional(prior: Map<string, CatalogueIndexEntry>): Pr
   console.log(`transactional: ${templates.length}`)
 
   return mapPool(templates, 4, async (t) => {
+    if (isTestEmail(t.name, undefined)) {
+      stats.skippedTest++
+      return null
+    }
     const metrics = toMetrics(await getTransactionalMetrics(t.id))
     if (!wasSent(metrics)) {
       stats.skippedUnsent++
@@ -496,6 +575,8 @@ async function main() {
       bySurface,
       withoutBody: stats.withoutBody,
       skippedUnsent: stats.skippedUnsent,
+      skippedTest: stats.skippedTest,
+      skippedAbContainers: stats.skippedAbContainers,
     },
     // Strip the heavy fields — the index page never needs HTML or link lists.
     emails: collected.map(({ entry }) => ({
@@ -522,6 +603,8 @@ async function main() {
   console.log(`  by surface: ${JSON.stringify(bySurface)}`)
   console.log(`  without body: ${stats.withoutBody}`)
   console.log(`  skipped (never sent): ${stats.skippedUnsent}`)
+  console.log(`  skipped (test names): ${stats.skippedTest}`)
+  console.log(`  skipped (A/B containers): ${stats.skippedAbContainers}`)
   if (stats.reusedBody) console.log(`  reused unchanged bodies: ${stats.reusedBody}`)
 }
 

--- a/src/lib/catalogue/filters.test.ts
+++ b/src/lib/catalogue/filters.test.ts
@@ -1,0 +1,94 @@
+import { test } from "node:test"
+import assert from "node:assert/strict"
+
+/**
+ * Mirrors the TEST_NAME pattern in scripts/ingest.ts.
+ *
+ * Duplicated deliberately: the ingest script isn't importable as a module (it
+ * reads argv at load), and this pattern is the one place a mistake silently
+ * deletes real emails from the archive, so it gets its own guard.
+ */
+const TEST_NAME = /(?<![a-z])test(?:s|ing)?(?![a-z])/i
+
+test("matches names that really are internal tests", () => {
+  for (const name of [
+    "Test ZC",
+    "EW Test Campaign",
+    "Clearbit Risk API Test",
+    "test",
+    "TEST",
+    "smoke-test",
+    "test2",
+    "load tests",
+    "testing welcome flow",
+    "QA_test_email",
+  ]) {
+    assert.ok(TEST_NAME.test(name), `should match: ${name}`)
+  }
+})
+
+test("does not match ordinary marketing copy containing the letters 'test'", () => {
+  // "Make the safe path the fastest path" is a real send in this workspace; a
+  // substring filter would have hidden it.
+  for (const name of [
+    "Make the safe path the fastest path",
+    "fastest",
+    "Our latest features",
+    "latest",
+    "greatest hits",
+    "Enter the contest",
+    "protest",
+    "A customer testimonial",
+    "testimonials",
+    "attestation",
+  ]) {
+    assert.ok(!TEST_NAME.test(name), `should NOT match: ${name}`)
+  }
+})
+
+test("real campaign names from the workspace are unaffected", () => {
+  for (const name of [
+    "global_em_vercel_ship-london-FUP_Registered_20260622_4529",
+    "NAMER_em_Vercel_Email-invite-2---EAA_20260813_MOPS-4813",
+    "apac_em_vercel_ship-syd-promo-1_20260701",
+    "global_nur_vercel_function-timeout-rescue_20260731_4649",
+  ]) {
+    assert.ok(!TEST_NAME.test(name), `should NOT match: ${name}`)
+  }
+})
+
+/**
+ * Mirrors the A/B container filter in emailActions().
+ *
+ * Customer.io returns a parent action alongside its variants; the parent has no
+ * body and metrics equal to the SUM of its children, so ingesting it both
+ * invents a bodiless email and double-counts every send.
+ */
+function dropAbContainers<T extends { id: number; parent_action_id?: number }>(actions: T[]): T[] {
+  const parentIds = new Set(
+    actions.map((a) => a.parent_action_id).filter((id): id is number => typeof id === "number"),
+  )
+  return actions.filter((a) => !parentIds.has(a.id))
+}
+
+test("drops the A/B parent and keeps its variants", () => {
+  // Campaign 43 as the API actually returns it.
+  const kept = dropAbContainers([
+    { id: 729 },
+    { id: 731 },
+    { id: 732, parent_action_id: 729 },
+    { id: 733, parent_action_id: 729 },
+  ])
+  assert.deepEqual(kept.map((a) => a.id), [731, 732, 733])
+})
+
+test("a campaign with no variants is left alone", () => {
+  const kept = dropAbContainers([{ id: 1 }, { id: 2 }, { id: 3 }])
+  assert.deepEqual(kept.map((a) => a.id), [1, 2, 3])
+})
+
+test("standalone actions are never mistaken for containers", () => {
+  // 731 has no parent and no children — a normal single email.
+  const kept = dropAbContainers([{ id: 731 }, { id: 732, parent_action_id: 729 }])
+  assert.ok(kept.some((a) => a.id === 731))
+})

--- a/src/lib/catalogue/filters.test.ts
+++ b/src/lib/catalogue/filters.test.ts
@@ -92,3 +92,47 @@ test("standalone actions are never mistaken for containers", () => {
   const kept = dropAbContainers([{ id: 731 }, { id: 732, parent_action_id: 729 }])
   assert.ok(kept.some((a) => a.id === 731))
 })
+
+/**
+ * Mirrors the strict type predicate in emailActions().
+ *
+ * The loose version ended in `|| Boolean(a.body)`, which admitted any journey
+ * step carrying content — so a webhook step surfaced as an email whose body was
+ * a JSON payload.
+ */
+function keepEmailActions<T extends { id: number; type?: string; body?: string; parent_action_id?: number }>(
+  actions: T[],
+): T[] {
+  const parents = new Set(
+    actions.map((a) => a.parent_action_id).filter((id): id is number => typeof id === "number").map(String),
+  )
+  const present = new Set(actions.map((a) => String(a.id)))
+  return actions.filter(
+    (a) => a.type === "email" && !(parents.has(String(a.id)) && present.has(String(a.id))),
+  )
+}
+
+test("non-email journey steps are excluded even when they carry a body", () => {
+  const kept = keepEmailActions([
+    { id: 1, type: "email", body: "<html>real</html>" },
+    { id: 2, type: "webhook", body: '{"email": "{{customer.email}}", "ip": "127.0.0.1"}' },
+    { id: 3, type: "attribute_update", body: '[{"name":"Created__c"}]' },
+    { id: 4, type: "create_event", body: '[{"name":"acceptance_date"}]' },
+  ])
+  assert.deepEqual(kept.map((a) => a.id), [1])
+})
+
+test("an email action with no body is still an email action", () => {
+  // Bodiless emails should be reported as such, not silently reclassified.
+  const kept = keepEmailActions([{ id: 1, type: "email" }])
+  assert.deepEqual(kept.map((a) => a.id), [1])
+})
+
+test("type and container filters compose", () => {
+  const kept = keepEmailActions([
+    { id: 729, type: "email" },
+    { id: 732, type: "email", body: "<html/>", parent_action_id: 729 },
+    { id: 900, type: "webhook", body: "{}" },
+  ])
+  assert.deepEqual(kept.map((a) => a.id), [732])
+})

--- a/src/lib/catalogue/types.ts
+++ b/src/lib/catalogue/types.ts
@@ -146,6 +146,10 @@ export interface CatalogueIndex {
     bySurface: Record<string, number>
     withoutBody: number
     skippedUnsent: number
+    /** Excluded by name as internal testing. */
+    skippedTest?: number
+    /** A/B parent actions dropped — see emailActions() in scripts/ingest.ts. */
+    skippedAbContainers?: number
   }
   emails: CatalogueIndexEntry[]
 }

--- a/src/lib/catalogue/types.ts
+++ b/src/lib/catalogue/types.ts
@@ -150,6 +150,8 @@ export interface CatalogueIndex {
     skippedTest?: number
     /** A/B parent actions dropped — see emailActions() in scripts/ingest.ts. */
     skippedAbContainers?: number
+    /** Webhook/attribute_update/create_event steps whose "body" is JSON, not markup. */
+    skippedNonEmail?: number
   }
   emails: CatalogueIndexEntry[]
 }

--- a/src/lib/cio/types.ts
+++ b/src/lib/cio/types.ts
@@ -99,6 +99,11 @@ export interface CioCampaignsResponse {
  * exists to keep it.
  */
 export interface CioAction {
+  /**
+   * Customer.io returns this as a STRING ("729") even though
+   * `parent_action_id` on the same object is a NUMBER. Compare the two only
+   * after normalising — see abContainerIds() in scripts/ingest.ts.
+   */
   id: number
   campaign_id?: number
   parent_action_id?: number


### PR DESCRIPTION
Two data-quality fixes found by running the ingest against the live workspace. Independent of #54 (disjoint files), so these can merge in either order.

## Why some emails had no body — they weren't emails

Both bodiless entries in the archive were **A/B test containers**, not messages.

When a journey step has variants, Customer.io returns a parent action alongside its children. The parent has no body, no `sending_state`, and metrics that are the **sum of its variants** — so ingesting it produced a phantom entry *and* double-counted every send:

| Action | Sends | |
|---|---|---|
| `729` (parent) | 7,070 | phantom, bodiless |
| `732` (variant) | 3,515 | real |
| `733` (variant) | 3,555 | real |

3,515 + 3,555 = 7,070 — the same sends counted twice. Same pattern in campaign 47 (8,872 = 4,393 + 4,479). Containers are now dropped; their variants are kept.

**Worth a look in review:** my first version of this filter silently did nothing. Customer.io returns `id` as a **string** (`"729"`) while `parent_action_id` on the same object is a **number** (`729`), so the `Set` lookup never matched. Both sides are normalised now, and the discrepancy is documented on `CioAction.id` so it isn't reintroduced.

## Test-named emails excluded

`--include-test` keeps them if needed.

The match is **word-boundary, not substring**, and that distinction matters more than it looks. A substring check would hide **"Make the safe path the fastest path"** — a real send in this workspace — because `fastest` contains `test`. `latest`, `greatest`, `contest` and `testimonial` are the same trap. `test`, `tests`, `testing`, `test2` match; those don't.

It checks the email's own name and its parent campaign's name, but deliberately **not the subject line**: subjects are customer-facing copy where "test" is legitimate ("A/B test your landing pages"), so matching there would hide real campaigns.

## Non-email journey steps excluded

The reported case: a **webhook step** appearing as an email whose rendering was its JSON payload — `{"email": "{{customer.email}}", "ip": "127.0.0.1"}`.

`emailActions()` ended in a `|| Boolean(a.body)` catch-all, so any journey step carrying content qualified as an email. But a journey also contains webhook, `attribute_update` and `create_event` steps, and several carry a `body` that is JSON, not markup:

| type | actions | with body | body |
|---|---|---|---|
| `email` | 161 | 98 | real HTML |
| `attribute_update` | 4 | 3 | JSON |
| `create_event` | 1 | 1 | JSON |
| `webhook` | 1 | 1 | JSON |

The type is now required to be exactly `"email"` rather than inferred from the presence of content. Every action Customer.io returned here has a type, so being strict loses nothing — and being loose means publishing webhook payloads as emails.

This also explains the nonsensical `skippedAbContainers: -5` I hit while building the container filter: the count subtracted list lengths, and exactly those 5 non-email actions were inflating the kept set. The negative number was a symptom of this bug, not just a bad statistic.

**Note the two filters are complementary.** The test-name filter removed that particular card only because its parent campaign happened to be called "Clearbit Risk API *Test*". A webhook in a normally-named, sending campaign would still have appeared, so the type predicate is the actual fix.

## Result on the live archive

| | before | after |
|---|---|---|
| Emails | 130 | **128** |
| Without a body | 2 | **0** |
| Test-named | 1 visible (+62 already unsent) | **0** |
| "fastest" send | present | **still present** |
| Non-email steps published as emails | 5 possible | **0** |

Exclusions reconcile exactly: 63 test + 45 unsent + 2 containers + 5 non-email.

## Verification

- 58 unit tests (9 new, covering the word-boundary pattern against real workspace names and the container filter against campaign 43's real action shape), `tsc --noEmit`, eslint — all clean.
- Full re-ingest against the live API, then verified in the snapshot: containers gone, variants kept, no bodiless entries, no test names in either `name` or `parentName`, and the `fastest` email still there.
- The type predicate verified **independently** by re-running with `--include-test`, which disables the filter that was accidentally hiding the webhook: it stays excluded, no non-HTML bodies remain, and the total is 128 either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
